### PR TITLE
Rm lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "html-react-parser": "^0.14.2",
     "install": "^0.13.0",
-    "lodash": "^4.17.20",
+    "lodash.clonedeep": "^4.5.0",
     "moment": "^2.29.1",
     "msgpack-lite": "^0.1.26",
     "net": "^1.0.2",

--- a/src/components/transactionsBTC/transactionsBTC.js
+++ b/src/components/transactionsBTC/transactionsBTC.js
@@ -2,7 +2,8 @@ import React, {useEffect, useState} from 'react';
 import {useDispatch} from 'react-redux'
 
 import {callDepositInit, callDepositConfirm, setNotification,
-  callGetUnconfirmedAndUnmindeCoinsFundingTxData, callRemoveCoin} from '../../features/WalletDataSlice'
+  callGetUnconfirmedAndUnmindeCoinsFundingTxData, callRemoveCoin,
+  callGetConfig} from '../../features/WalletDataSlice'
 import {fromSatoshi} from '../../wallet'
 import { CopiedButton } from '../../components'
 
@@ -20,6 +21,13 @@ const TransactionsBTC = (props) => {
   const [state, setState] = useState({});
 
   const dispatch = useDispatch();
+
+  let testing_mode;
+  try {
+    testing_mode = callGetConfig().testing_mode;
+  } catch {
+    testing_mode = false;
+  }
 
   // First of all run depositInit for selected deposit amount if not already complete
   props.selectedValues.forEach((item, id) => {
@@ -84,9 +92,13 @@ const TransactionsBTC = (props) => {
     <div className=" deposit">
       {populateWithTransactionDisplayPanels}
       <div className="Body">
+        {testing_mode ?
           <button type="button" className="std-button" onClick={despositConfirm}>
               PERFORM DEPOSIT CONFIRM
           </button>
+        :
+          null
+        }
       </div>
     </div>
   )

--- a/src/wallet/config.ts
+++ b/src/wallet/config.ts
@@ -3,7 +3,7 @@
 import { Network } from "bitcoinjs-lib/types/networks";
 import { ElectrumClientConfig } from "./electrum";
 
-let lodash = require('lodash');
+let cloneDeep = require('lodash.clonedeep');
 
 const DEFAULT_STATE_ENTITY_ENPOINT = "https://fakeapi.mercurywallet.io";
 
@@ -49,7 +49,7 @@ export class Config {
   }
 
   getConfig() {
-    return lodash.cloneDeep(this)
+    return cloneDeep(this)
   }
 
   // update by providing JSONObject with new values

--- a/src/wallet/mercury/transfer.ts
+++ b/src/wallet/mercury/transfer.ts
@@ -7,7 +7,7 @@ import { keyGen, PROTOCOL, sign } from "./ecdsa";
 import { encodeSecp256k1Point, StateChainSig, proofKeyToSCEAddress, pubKeyToScriptPubKey, encryptECIES, decryptECIES, getSigHash } from "../util";
 
 let bitcoin = require("bitcoinjs-lib");
-let lodash = require('lodash');
+let cloneDeep = require('lodash.clonedeep');
 let types = require("../types")
 let typeforce = require('typeforce');
 let BN = require('bn.js');
@@ -42,7 +42,7 @@ export const transferSender = async (
   // Checks for spent, owned etc here
   let new_tx_backup;
   if (statecoin.tx_backup) {
-    new_tx_backup = lodash.cloneDeep(statecoin.tx_backup);
+    new_tx_backup = cloneDeep(statecoin.tx_backup);
   } else {
     throw Error("Back up tx does not exist. Statecoin deposit is not complete.")
   }

--- a/src/wallet/mocks/mock_http_client.ts
+++ b/src/wallet/mocks/mock_http_client.ts
@@ -2,9 +2,9 @@
 // Mock Classes  are followed by mock data for full protocol runs.
 
 import { GET_ROUTE, POST_ROUTE } from "../http_client"
-import { SIGNSWAPTOKEN_DATA, BST_DATA } from "../test/test_data";
+// import { SIGNSWAPTOKEN_DATA, BST_DATA } from "../test/test_data";
 
-let lodash = require('lodash');
+let cloneDeep = require('lodash.clonedeep');
 
 export class MockHttpClient {
   get = async (path: string, _params: any) => {
@@ -12,11 +12,11 @@ export class MockHttpClient {
       case GET_ROUTE.PING:
         return true
       case GET_ROUTE.FEES:
-        return lodash.cloneDeep(FEE_INFO)
+        return cloneDeep(FEE_INFO)
       case GET_ROUTE.ROOT:
-        return lodash.cloneDeep(ROOT_INFO)
+        return cloneDeep(ROOT_INFO)
       case GET_ROUTE.STATECHAIN:
-        return lodash.cloneDeep(STATECHAIN_INFO)
+        return cloneDeep(STATECHAIN_INFO)
       case GET_ROUTE.TRANSFER_BATCH:
         return {
           status: true
@@ -120,7 +120,7 @@ export const POLL_SWAP_END = "End"
 
 // export const GET_SWAP_INFO_1 = {
 //   status: "Phase1",
-//   swap_token: lodash.cloneDeep(SIGNSWAPTOKEN_DATA)[0].swap_token,
+//   swap_token: cloneDeep(SIGNSWAPTOKEN_DATA)[0].swap_token,
 //   bst_sender_data: BST_DATA.bst_sender_data,
 // }
 

--- a/src/wallet/test/mercury.test.js
+++ b/src/wallet/test/mercury.test.js
@@ -12,9 +12,9 @@ import * as MOCK_SERVER from '../mocks/mock_http_client'
 
 import { BIP32Interface, BIP32,  fromBase58, fromSeed} from 'bip32';
 
-let bitcoin = require('bitcoinjs-lib')
-let lodash = require('lodash');
-const BJSON = require('buffer-json')
+let bitcoin = require('bitcoinjs-lib');
+let cloneDeep = require('lodash.clonedeep');
+const BJSON = require('buffer-json');
 
 // client side's mock
 let wasm_mock = jest.genMockFromModule('../mocks/mock_wasm');
@@ -82,7 +82,7 @@ describe('StateChain Entity', function() {
       expect(statecoin_finalized.smt_proof).not.toBeNull();
     });
     test('Fee too large for amount.', async function() {
-      let fee_info = lodash.clone(MOCK_SERVER.FEE_INFO);
+      let fee_info = cloneDeep(MOCK_SERVER.FEE_INFO);
       fee_info.withdraw = 10000;
 
       http_mock.get = jest.fn().mockReset()
@@ -118,7 +118,7 @@ describe('StateChain Entity', function() {
   describe('Withdraw', function() {
     test('Expect complete', async function() {
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(lodash.cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
         .mockReturnValueOnce(MOCK_SERVER.FEE_INFO);
       http_mock.post = jest.fn().mockReset()
         .mockReturnValueOnce(true)   //POST.WITHDRAW_INIT
@@ -143,7 +143,7 @@ describe('StateChain Entity', function() {
       expect(tx_withdraw.locktime).toBe(0);
     });
     test('Already withdrawn.', async function() {
-      let statechain_info = lodash.cloneDeep(MOCK_SERVER.STATECHAIN_INFO);
+      let statechain_info = cloneDeep(MOCK_SERVER.STATECHAIN_INFO);
       statechain_info.amount = 0;
       http_mock.get = jest.fn().mockReset()
         .mockReturnValueOnce(statechain_info)
@@ -154,7 +154,7 @@ describe('StateChain Entity', function() {
     });
     test('StateChain not owned by this wallet.', async function() {
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(lodash.cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
 
       let statecoin = makeTesterStatecoin();
       statecoin.proof_key = "aaa";
@@ -163,11 +163,11 @@ describe('StateChain Entity', function() {
         .toThrowError("StateChain not owned by this Wallet. Incorrect proof key.");
     });
     test('Fee too large for amount.', async function() {
-      let fee_info = lodash.clone(MOCK_SERVER.FEE_INFO);
+      let fee_info = cloneDeep(MOCK_SERVER.FEE_INFO);
       fee_info.withdraw = 10000;
 
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(lodash.cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
         .mockReturnValueOnce(fee_info)
       http_mock.post = jest.fn().mockReset()
         .mockReturnValueOnce(true)   //POST.WITHDRAW_INIT
@@ -184,7 +184,7 @@ describe('StateChain Entity', function() {
     test('Expect complete', async function() {
       http_mock.get = jest.fn().mockReset()
         .mockReturnValueOnce(MOCK_SERVER.FEE_INFO)
-        .mockReturnValueOnce(lodash.cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
       http_mock.post = jest.fn().mockReset()
         .mockReturnValueOnce(MOCK_SERVER.TRANSFER_SENDER)
       //Sign
@@ -231,14 +231,14 @@ describe('StateChain Entity', function() {
     test('Expect complete', async function() {
       http_mock.get = jest.fn().mockReset()
         .mockReturnValueOnce(MOCK_SERVER.STATECHAIN_INFO_AFTER_TRANSFER)
-        .mockReturnValueOnce(lodash.cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
       http_mock.post = jest.fn().mockReset()
         .mockReturnValueOnce(MOCK_SERVER.TRANSFER_PUBKEY)
         .mockReturnValueOnce(MOCK_SERVER.TRANSFER_RECEIVER)
       //POST.TRANSFER_UPDATE_MSG;
         .mockReturnValueOnce(true)
 
-      let transfer_msg3 = lodash.cloneDeep(MOCK_SERVER.TRANSFER_MSG3);
+      let transfer_msg3 = cloneDeep(MOCK_SERVER.TRANSFER_MSG3);
       let se_rec_addr_bip32 = bitcoin.ECPair.fromPrivateKey(Buffer.from(MOCK_SERVER.STATECOIN_PROOF_KEY_DER_AFTER_TRANSFER.__D));
       let finalize_data = await transferReceiver(http_mock, transfer_msg3, se_rec_addr_bip32, null);
 
@@ -248,7 +248,7 @@ describe('StateChain Entity', function() {
       http_mock.get = jest.fn().mockReset()
         .mockReturnValueOnce(MOCK_SERVER.STATECHAIN_INFO_AFTER_TRANSFER)
 
-      let transfer_msg3 = lodash.cloneDeep(MOCK_SERVER.TRANSFER_MSG3);
+      let transfer_msg3 = cloneDeep(MOCK_SERVER.TRANSFER_MSG3);
       transfer_msg3.statechain_sig.sig = "3044022026a22bb2b8c0e43094d9baa9de1abd1de914b59f8bbcf5b740900180da575ed10220544e27e2861edf01b5c383fc90d8b1fd41211628516789f771b2c3536e650bdb";
 
       await expect(transferReceiver(http_mock, transfer_msg3, {}, null))
@@ -259,7 +259,7 @@ describe('StateChain Entity', function() {
       http_mock.get = jest.fn().mockReset()
         .mockReturnValueOnce(MOCK_SERVER.STATECHAIN_INFO_AFTER_TRANSFER)
 
-      let transfer_msg3 = lodash.cloneDeep(MOCK_SERVER.TRANSFER_MSG3);
+      let transfer_msg3 = cloneDeep(MOCK_SERVER.TRANSFER_MSG3);
       let se_rec_addr_bip32 = bitcoin.ECPair.fromPrivateKey(Buffer.from(MOCK_SERVER.STATECOIN_PROOF_KEY_DER_AFTER_TRANSFER.__D));
       se_rec_addr_bip32.__D = Buffer.from("0ca756f401478fb1a166d27945501d8af59ada1cb552c598509dfcb494f475b9", "hex")
 
@@ -285,7 +285,7 @@ describe('StateChain Entity', function() {
       http_mock.post
         .mockReturnValueOnce(MOCK_SERVER.SMT_PROOF);
 
-      let finalize_data = BJSON.parse(lodash.cloneDeep(FINALIZE_DATA));
+      let finalize_data = BJSON.parse(cloneDeep(FINALIZE_DATA));
       let statecoin = await transferReceiverFinalize(http_mock, wasm_mock, finalize_data);
 
       expect(statecoin.statechain_id).toBe(finalize_data.statechain_id);

--- a/src/wallet/test/swap.test.js
+++ b/src/wallet/test/swap.test.js
@@ -7,8 +7,6 @@ import * as MOCK_SERVER from '../mocks/mock_http_client'
 import {fromSeed} from 'bip32';
 
 let bitcoin = require('bitcoinjs-lib')
-let lodash = require('lodash');
-
 
 // client side's mock
 let wasm_mock = jest.genMockFromModule('../mocks/mock_wasm');

--- a/src/wallet/test/wallet.test.js
+++ b/src/wallet/test/wallet.test.js
@@ -7,7 +7,7 @@ import { txWithdrawBuild } from '../util';
 import { addRestoredCoinDataToWallet } from '../recovery';
 import { RECOVERY_DATA, RECOVERY_DATA_C_KEY_CONVERTED } from './test_data';
 
-let lodash = require('lodash');
+let cloneDeep = require('lodash.clonedeep');
 
 const SHARED_KEY_DUMMY = {public:{q: "",p2: "",p1: "",paillier_pub: {},c_key: "",},private: "",chain_code: ""};
 
@@ -208,7 +208,7 @@ describe("Statecoins/Coin", () => {
 
   describe("calcExpiryDate", () => {
     it('Calculate expiry', () => {
-      let coin = lodash.clone(statecoins.coins[0]);
+      let coin = cloneDeep(statecoins.coins[0]);
       let tx_backup = new Transaction();
       let locktime = 24*6*30; // month locktime
       tx_backup.locktime = locktime;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -22,7 +22,7 @@ let bitcoin = require('bitcoinjs-lib');
 let bip32utils = require('bip32-utils');
 let bip32 = require('bip32');
 let bip39 = require('bip39');
-let lodash = require('lodash');
+let cloneDeep = require('lodash.clonedeep');
 
 // Logger import.
 // Node friendly importing required for Jest tests.
@@ -146,12 +146,12 @@ export class Wallet {
   // Save entire wallet to storage. Store in file as JSON Object.
 
   save() {
-    let wallet_json = lodash.cloneDeep(this)
+    let wallet_json = cloneDeep(this)
     this.storage.storeWallet(wallet_json)
   };
   // Update account in storage.
   saveKeys() {
-    let account = lodash.cloneDeep(this.account)
+    let account = cloneDeep(this.account)
     this.storage.storeWalletKeys(this.name, account)
   };
 


### PR DESCRIPTION
1) Found option to install only lodash methods that we require instead of entire lib
2) replace lodash imports with loadash.cloneDeep
3) Turns out other dependencies themselves depend on full lodash library anyway
4) save 0.1 MB in compiled .dmg :confused: