### PR TITLE
Get transfers

### DIFF
--- a/src/containers/Receive/Receive.js
+++ b/src/containers/Receive/Receive.js
@@ -38,10 +38,10 @@ const ReceiveStatecoinPage = () => {
     // if mgs box empty, then query server for transfer messages
     if (!transfer_msg3) {
       dispatch(callGetTransfers()).then((res) => {
-        if (res.payload.received===0) {
-            dispatch(setError({msg: "No transfers to receive."})
+        if (res.payload===0) {
+            dispatch(setError({msg: "No transfers to receive."}))
          } else {
-          let nreceived = res.payload.received
+          let nreceived = res.payload
           dispatch(setNotification({msg:"Received "+nreceived+" statecoins."}))
         }
       })

--- a/src/containers/Receive/Receive.js
+++ b/src/containers/Receive/Receive.js
@@ -5,7 +5,7 @@ import {useDispatch} from 'react-redux'
 import {StdButton, AddressInput, CopiedButton} from "../../components";
 import QRCode from 'qrcode.react';
 
-import {isWalletLoaded, callNewSeAddr, callGetSeAddr, callTransferReceiver, setError, setNotification} from '../../features/WalletDataSlice'
+import {isWalletLoaded, callNewSeAddr, callGetSeAddr, callTransferReceiver, callGetTransfers, setError, setNotification} from '../../features/WalletDataSlice'
 import {fromSatoshi} from '../../wallet'
 
 import arrow from "../../images/arrow-up.png"
@@ -35,9 +35,16 @@ const ReceiveStatecoinPage = () => {
   }
 
   const receiveButtonAction =() => {
-    // check statechain is chosen
+    // if mgs box empty, then query server for transfer messages
     if (!transfer_msg3) {
-      dispatch(setError({msg: "Paste TransferMsg3 to perform transfer receiver."}))
+      dispatch(callGetTransfers()).then((res) => {
+        if (res.payload.received===0) {
+            dispatch(setError({msg: "No transfers to receive."})
+         } else {
+          let nreceived = res.payload.received
+          dispatch(setNotification({msg:"Received "+nreceived+" statecoins."}))
+        }
+      })
       return
     }
 

--- a/src/features/WalletDataSlice.js
+++ b/src/features/WalletDataSlice.js
@@ -200,6 +200,12 @@ export const callTransferReceiver = createAsyncThunk(
     return wallet.transfer_receiver(decodeMessage(action, network))
   }
 )
+export const callGetTransfers = createAsyncThunk(
+  'GetTransfers',
+  async (action, thunkAPI) => {
+    return wallet.get_transfers()
+  }
+)
 export const callDoSwap = createAsyncThunk(
   'DoSwap',
   async (action, thunkAPI) => {
@@ -331,6 +337,9 @@ const WalletSlice = createSlice({
       state.error_dialogue = { seen: false, msg: action.error.name+": "+action.error.message }
     },
     [callTransferReceiver.rejected]: (state, action) => {
+      state.error_dialogue = { seen: false, msg: action.error.name+": "+action.error.message }
+    },
+    [callGetTransfers.rejected]: (state, action) => {
       state.error_dialogue = { seen: false, msg: action.error.name+": "+action.error.message }
     },
     [callDoSwap.rejected]: (state, action) => {

--- a/src/settings.json
+++ b/src/settings.json
@@ -3,7 +3,7 @@
   "state_entity_endpoint": "https://beta.mercurywallet.io",
   "swap_conductor_endpoint": "https://beta.mercurywallet.io",
   "network": "testnet",
-  "testing_mode": false,
+  "testing_mode": true,
   "tor_proxy": {"ip": "localhost",
                 "port": 9050,
                 "controlPassword": "password",

--- a/src/settings.json
+++ b/src/settings.json
@@ -3,7 +3,7 @@
   "state_entity_endpoint": "https://beta.mercurywallet.io",
   "swap_conductor_endpoint": "https://beta.mercurywallet.io",
   "network": "testnet",
-  "testing_mode": true,
+  "testing_mode": false,
   "tor_proxy": {"ip": "localhost",
                 "port": 9050,
                 "controlPassword": "password",

--- a/src/wallet/http_client.ts
+++ b/src/wallet/http_client.ts
@@ -8,7 +8,8 @@ export const GET_ROUTE = {
   STATECHAIN: "info/statechain",
   COINS_INFO: "info/coins",
   TRANSFER_BATCH: "info/transfer-batch",
-  SWAP_GROUPINFO: "swap/groupinfo"
+  SWAP_GROUPINFO: "swap/groupinfo",
+  TRANSFER_GET_MSG_ADDR: "transfer/get_msg_addr",
 };
 Object.freeze(GET_ROUTE);
 

--- a/src/wallet/statecoin.ts
+++ b/src/wallet/statecoin.ts
@@ -107,6 +107,15 @@ export class StateCoinList {
     return this.coins.find(coin => coin.shared_key_id === shared_key_id)
   }
 
+  getCoins(statechain_id: string) {
+    return this.coins.filter((item: StateCoin) => {
+      if (item.statechain_id === statechain_id) {
+        return item
+      }
+      return null
+    })
+  }  
+
   // creates new coin with Date.now()
   addNewCoin(shared_key_id: string, shared_key: MasterKey2) {
     this.coins.push(new StateCoin(shared_key_id, shared_key))

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -3,7 +3,7 @@
 import { BIP32Interface, Network, Transaction } from 'bitcoinjs-lib';
 import { ACTION, ActivityLog, ActivityLogItem } from './activity_log';
 import { ElectrumClient, MockElectrumClient, HttpClient, MockHttpClient, StateCoinList,
-  MockWasm, StateCoin, pubKeyTobtcAddr, fromSatoshi, STATECOIN_STATUS, BACKUP_STATUS, decryptAES,
+  MockWasm, StateCoin, pubKeyTobtcAddr, fromSatoshi, STATECOIN_STATUS, BACKUP_STATUS, GET_ROUTE, decryptAES,
   encodeSCEAddress} from './';
 
 import { txCPFPBuild, FEE } from './util';
@@ -691,6 +691,11 @@ export class Wallet {
   // Args: transfer_messager retuned from sender's TransferSender
   // Return: New wallet coin data
   async transfer_receiver(transfer_msg3: TransferMsg3): Promise<TransferFinalizeData> {
+    let walletcoins = this.statecoins.getCoins(transfer_msg3.statechain_id);
+    for (let i=0; i<walletcoins.length; i++) {
+      if(walletcoins[i].status===STATECOIN_STATUS.AVAILABLE) throw Error("Transfer completed.");
+    }
+
     log.info("Transfer Receiver for statechain "+transfer_msg3.statechain_id)
     let tx_backup = Transaction.fromHex(transfer_msg3.tx_backup_psm.tx_hex);
 
@@ -725,6 +730,45 @@ export class Wallet {
     this.saveStateCoinsList();
     return statecoin_finalized
   }
+
+  // Query server for any pending transfer messages
+  // Check for unused proof keys
+  async get_transfers(): Promise<number> {
+  log.info("Retriving transfer messages")
+
+  let num_transfers = 0;
+  // loop over active addresses
+  for (let i=0; i<this.account.chains[0].addresses.length; i++) {
+    let addr = this.account.chains[0].addresses[i];
+
+    let proofkey = this.account.derive(addr).publicKey.toString("hex");
+    console.log(proofkey)
+    let transfer_msgs = await this.http_client.get(GET_ROUTE.TRANSFER_GET_MSG_ADDR, proofkey);
+    
+    console.log(transfer_msgs.length);
+
+    for (let i=0; i<transfer_msgs.length; i++) {
+      // check if the coin is in the wallet
+      let walletcoins = this.statecoins.getCoins(transfer_msgs[i].statechain_id);
+      console.log(walletcoins);
+      let dotransfer = true;
+      for (let j=0; j<walletcoins.length; j++) {
+        if(walletcoins[j].status===STATECOIN_STATUS.AVAILABLE) {
+          dotransfer = false;
+          break;
+        }
+      }
+      //perform transfer receiver
+      if (dotransfer) {
+         console.log("dotransfer");
+         let transfer_data = await this.transfer_receiver(transfer_msgs[i]);
+         num_transfers += 1;
+      }
+    }
+  }
+    return num_transfers
+  }
+
 
   // Perform withdraw
   // Args: statechain_id of coin to withdraw


### PR DESCRIPTION
Statecoin transfers can be received without the transfer message - by leaving the message box empty, the wallet queries the server by proof key (SE address) to fetch the transfer messages, and then completes them. 

Will update the UI in a separate PR. 