### PR TITLE
Deposit confirm on tx

### DIFF
--- a/src/containers/Withdraw/Withdraw.js
+++ b/src/containers/Withdraw/Withdraw.js
@@ -82,7 +82,6 @@ const WithdrawPage = () => {
         dispatch(setNotification({msg:"Withdraw to "+inputAddr+" Complete!"}))
       }
     }))
-
   }
 
   const filterByMsg = () => {

--- a/src/features/WalletDataSlice.js
+++ b/src/features/WalletDataSlice.js
@@ -185,7 +185,7 @@ export const callDepositConfirm = createAsyncThunk(
 export const callWithdraw = createAsyncThunk(
   'depositWithdraw',
   async (action, thunkAPI) => {
-    return wallet.withdraw(action.shared_key_id, action.rec_addr, action.fee_per_kb)
+    return wallet.withdraw(action.shared_key_ids, action.rec_addr, action.fee_per_kb)
   }
 )
 export const callTransferSender = createAsyncThunk(

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -287,9 +287,15 @@ export class Wallet {
   // Each time we get unconfirmed coins call this to check for confirmations
   checkUnconfirmedCoinsStatus(unconfirmed_coins: StateCoin[]) {
     unconfirmed_coins.forEach((statecoin) => {
+      // if we have the funding transaction, finalize creation and backup
+      if ((statecoin.status===STATECOIN_STATUS.UNCONFIRMED || statecoin.status===STATECOIN_STATUS.IN_MEMPOOL) && statecoin.tx_backup===null ) {
+          this.depositConfirm(statecoin.shared_key_id)
+      }
       if (statecoin.status===STATECOIN_STATUS.UNCONFIRMED &&
         statecoin.getConfirmations(this.block_height) >= this.config.required_confirmations) {
-          this.depositConfirm(statecoin.shared_key_id)
+          statecoin.setConfirmed();
+          // update in wallet
+          this.statecoins.setCoinFinalized(statecoin);
       }
     })
   }
@@ -311,7 +317,7 @@ export class Wallet {
   getCoinBackupTxData(shared_key_id: string) {
     let statecoin = this.statecoins.getCoin(shared_key_id);
     if (statecoin===undefined) throw Error("StateCoin does not exist.");
-    if (statecoin.status!==STATECOIN_STATUS.AVAILABLE) throw Error("StateCoin is not availble.");
+    if (statecoin.status===STATECOIN_STATUS.INITIALISED) throw Error("StateCoin is not availble.");
 
     // Get tx hex
     let backup_tx_data = statecoin.getBackupTxData(this.getBlockHeight());
@@ -580,7 +586,7 @@ export class Wallet {
   async depositConfirm(
     shared_key_id: string
   ): Promise<StateCoin> {
-    log.info("Depositing Confirm shared_key_id: "+shared_key_id);
+    log.info("Depositing Backup Confirm shared_key_id: "+shared_key_id);
 
     let statecoin = this.statecoins.getCoin(shared_key_id);
     if (statecoin === undefined) throw Error("Coin "+shared_key_id+" does not exist.");
@@ -596,10 +602,9 @@ export class Wallet {
     );
 
     // update in wallet
-    statecoin_finalized.setConfirmed();
     this.statecoins.setCoinFinalized(statecoin_finalized);
 
-    log.info("Deposit Confirm done.");
+    log.info("Deposit Backup done.");
     this.saveStateCoinsList();
     return statecoin_finalized
   }


### PR DESCRIPTION
Deposit_confirm is now completed as soon as the deposit tx is found in the mempool. This means that the owner always has the backup tx (protects against the server disappearing between deposit tx sending and 3 confs - could be days potentially). 

The statecoin status in the wallet is not updated (and remains unspendable/swappable) until the required confirmations are received. 