### PR TITLE
filter options in empty lists

### DIFF
--- a/src/components/coins/coins.js
+++ b/src/components/coins/coins.js
@@ -290,7 +290,7 @@ const Coins = (props) => {
         </div>
     )})
 
-    if(!all_coins_data.length) {
+    if(!all_coins_data.length && filterBy !== STATECOIN_STATUS.WITHDRAWN && filterBy !== STATECOIN_STATUS.IN_TRANSFER) {
       return (
         <div className="empty-coin-list">
           <svg

--- a/src/containers/Swap/Swap.js
+++ b/src/containers/Swap/Swap.js
@@ -159,7 +159,6 @@ const SwapPage = () => {
                           setSelectedSwap={setSelectedSwap}
                         />
                     </div>
-                    {swapGroupsData.length ? (
                       <div className="swap-footer-btns">
                         <button type="button" className="btn" onClick={swapButtonAction}>
                           Join Group
@@ -168,7 +167,6 @@ const SwapPage = () => {
                           Leave Group
                         </button>
                       </div>
-                    ) : null}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Enables returning to spendable coins list if in_transfer or withdrawn are empty. 