### PR TITLE
Fix/414 connection info box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ wallet.json
 yarn.lock
 
 src/react-app-env.d.ts
+
+.env

--- a/src/components/panelConnectivity/panelConnectivity.css
+++ b/src/components/panelConnectivity/panelConnectivity.css
@@ -133,6 +133,7 @@ label {
     border:0.5px solid rgba(0, 0, 0, 0.15);
     z-index: 1;
     font-size:0.725rem;
+    margin-left: 0.5%;
 
 }
 
@@ -149,6 +150,7 @@ label {
     border:0.5px solid rgba(0, 0, 0, 0.15);
     z-index: 1;
     font-size:0.725rem;
+    margin-left: 0.5%;
     
 }
 

--- a/src/components/panelConnectivity/panelConnectivity.css
+++ b/src/components/panelConnectivity/panelConnectivity.css
@@ -122,6 +122,40 @@ label {
     white-space: nowrap;
 }
 
+/* URL that shows up on hover */
+
+.url-hover-server{
+
+    background-color: #fff;
+    display: inline-block !important;
+    position:absolute;
+    box-shadow: rgba(0, 0, 0, 0.15) 0px 3px 3px 0px;
+    border:0.5px solid rgba(0, 0, 0, 0.15);
+    z-index: 1;
+    font-size:0.725rem;
+
+}
+
+.url-hover-hide-server{
+    overflow:hidden;
+}
+
+.url-hover-swaps{
+
+    background-color: #fff;
+    display: inline-block !important;
+    position:absolute;
+    box-shadow: rgba(0, 0, 0, 0.15) 0px 3px 3px 0px;
+    border:0.5px solid rgba(0, 0, 0, 0.15);
+    z-index: 1;
+    font-size:0.725rem;
+    
+}
+
+.url-hover-hide-swaps{
+    overflow:hidden;
+}
+
 @media only screen and (max-width: 768px) {
     .Body.small {
         padding: 16px;

--- a/src/components/panelConnectivity/panelConnectivity.js
+++ b/src/components/panelConnectivity/panelConnectivity.js
@@ -109,11 +109,11 @@ const PanelConnectivity = (props) => {
                 <div className="collapse-content-item">
                     <span className="host server" onMouseEnter={toggleURL}  onMouseLeave={toggleURL}>
 
-                        Host:
+                        Host: 
                         {state.isServerHover ? 
-                        (<span className ={state.isServerHover ? "url-hover-server": 'url-hover-hide-server'}>{current_config.state_entity_endpoint}</span>)
+                        (<span className ={state.isServerHover ? "url-hover-server": 'url-hover-hide-server'}>{ current_config.state_entity_endpoint}</span>)
                         :
-                        (`${shortenURLs(current_config.state_entity_endpoint)}`)}
+                        (` ${shortenURLs(current_config.state_entity_endpoint)}`)}
 
                     </span>
                     <span>Deposit Fee: <b>{fee_info.deposit /100}%</b></span>
@@ -123,11 +123,11 @@ const PanelConnectivity = (props) => {
                 <div className="collapse-content-item">
                     <span className="host swaps" onMouseEnter={toggleURL} onMouseLeave={toggleURL}>
                         
-                        Host:
+                        Host: 
                         {state.isSwapsHover ? 
-                        (<span className ={state.isSwapsHover ? "url-hover-swaps": 'url-hover-hide-swaps'}>{current_config.swap_conductor_endpoint}</span>)
+                        (<span className ={state.isSwapsHover ? "url-hover-swaps": 'url-hover-hide-swaps'}>{ current_config.swap_conductor_endpoint}</span>)
                         :
-                        (`${shortenURLs(current_config.swap_conductor_endpoint)}`)}
+                        (` ${shortenURLs(current_config.swap_conductor_endpoint)}`)}
 
                     </span>
                     <span>Pending Swaps: <b>{pending_swaps}</b></span>

--- a/src/components/panelConnectivity/panelConnectivity.js
+++ b/src/components/panelConnectivity/panelConnectivity.js
@@ -11,11 +11,32 @@ import '../index.css';
 
 
 const PanelConnectivity = (props) => {
-  // Arrow down state
-  const [state, setState] = useState({isToggleOn: false});
+  // Arrow down state and url hover state
+  const [state, setState] = useState({isToggleOn: false,
+    isServerHover:false, isSwapsHover:false});
+
   const toggleContent = (event) => {
       setState({isToggleOn: !state.isToggleOn})
   }
+  const toggleURL = (event) => {
+      let hostCheck = event.target.classList.value
+      if (hostCheck.includes("server")){
+        setState({...state,isServerHover:!state.isServerHover})
+      }
+      if(hostCheck.includes("swaps")){
+        setState({...state,isSwapsHover:!state.isSwapsHover})
+      }
+  }
+
+  //function shortens urls to fit better with styling
+  function shortenURLs(url){
+    let shortURL = ""
+    
+    url = url.replace("http://","")
+    shortURL = shortURL.concat(url.slice(0,3),"...",url.slice(url.length-8,url.length))
+    
+    return shortURL
+    }
 
   let current_config;
   try {
@@ -86,13 +107,29 @@ const PanelConnectivity = (props) => {
         <div className={state.isToggleOn ? "show" : ' hide'}>
             <div className="collapse-content">
                 <div className="collapse-content-item">
-                    <span className="host">Host: {current_config.state_entity_endpoint}</span>
+                    <span className="host server" onMouseEnter={toggleURL}  onMouseLeave={toggleURL}>
+
+                        Host:
+                        {state.isServerHover ? 
+                        (<span className ={state.isServerHover ? "url-hover-server": 'url-hover-hide-server'}>{current_config.state_entity_endpoint}</span>)
+                        :
+                        (`${shortenURLs(current_config.state_entity_endpoint)}`)}
+
+                    </span>
                     <span>Deposit Fee: <b>{fee_info.deposit /100}%</b></span>
                     <span>Withdraw Fee: <b>{fee_info.withdraw/100}%</b></span>
                     <span>{fee_info.endpoint}</span>
                 </div>
                 <div className="collapse-content-item">
-                    <span className="host">Host: {current_config.swap_conductor_endpoint}</span>
+                    <span className="host swaps" onMouseEnter={toggleURL} onMouseLeave={toggleURL}>
+                        
+                        Host:
+                        {state.isSwapsHover ? 
+                        (<span className ={state.isSwapsHover ? "url-hover-swaps": 'url-hover-hide-swaps'}>{current_config.swap_conductor_endpoint}</span>)
+                        :
+                        (`${shortenURLs(current_config.swap_conductor_endpoint)}`)}
+
+                    </span>
                     <span>Pending Swaps: <b>{pending_swaps}</b></span>
                     <span>Participants: <b>{participants}</b></span>
                     <span>Total pooled BTC: <b>{total_pooled_btc / Math.pow(10, 8)}</b></span>


### PR DESCRIPTION
<img width="231" alt="Screenshot 2021-06-15 at 14 44 00" src="https://user-images.githubusercontent.com/72019925/122063430-2b731080-cde8-11eb-9a84-381cc0baaacf.png">


The urls are truncated

<img width="469" alt="Screenshot 2021-06-15 at 14 44 10" src="https://user-images.githubusercontent.com/72019925/122063443-2d3cd400-cde8-11eb-9b0f-5b1aca8a3464.png">

Then a box with the full URL appears over the truncated URL on hover