### PR TITLE
Enable endpoint change via settings

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -81,18 +81,14 @@ export class Wallet {
     this.electrum_client = this.newElectrumClient();
 
     this.http_client = new HttpClient('http://localhost:3001', true);
-    let se_tor_config = {
-      tor_proxy: this.config.tor_proxy,
-      state_entity_endpoint: this.config.state_entity_endpoint
-    }
-    //this.http_client.post('tor_settings', se_tor_config);
-    
     this.conductor_client = new HttpClient('http://localhost:3001', true);
-    let cond_tor_config = {
+    let tor_config = {
       tor_proxy: this.config.tor_proxy,
-      swap_conductor_endpoint: this.config.swap_conductor_endpoint
+      swap_conductor_endpoint: this.config.swap_conductor_endpoint,
+      state_entity_endpoint: this.config.state_entity_endpoint,
     }
-    //this.conductor_client.post('tor_settings', cond_tor_config);
+    console.log('posting tor config: {}' + JSON.stringify(tor_config));
+    this.http_client.post('tor_settings', tor_config);
             
     this.block_height = 0;
     this.current_sce_addr = "";

--- a/tor-adapter/server/index.js
+++ b/tor-adapter/server/index.js
@@ -90,7 +90,7 @@ app.post('/tor_settings', async function(req,res) {
     config.update(req.body);
     await tor.stopTorNode();
     tor.set(config.tor_proxy);
-    await tor.startTorNode();
+    await tor.startTorNode(tor_cmd, torrc);
     let response = {
       tor_proxy: config.tor_proxy,
       state_entity_endpoint: config.state_entity_endpoint,


### PR DESCRIPTION
The state entity and conductor urls can be changed from the settings page.