### PR TITLE
Fix/454 prevent specialchars walletnames

### DIFF
--- a/src/components/createWizardForm/createWizardForm.js
+++ b/src/components/createWizardForm/createWizardForm.js
@@ -34,7 +34,13 @@ const CreateWizardForm = (props) => {
                   <input id="Name" type="text" name="Wallet Name" placeholder="Wallet Name"
                     value={props.wizardState.wallet_name}
                     onChange={props.setStateWalletName}
+                    ref = {register({
+                        validate: value => (!value.includes('.')&&!value.includes('/') || "Certain characters prohibited from use in Wallet Name")
+                    })}
                     required/>
+                </div>
+                <div className="error">
+                    {errors["Wallet Name"] && <p>{errors["Wallet Name"].message}</p>}
                 </div>
                 <div className="inputs-item">
                     <p>Enter a password for your wallet. Leave blank for no password.</p>

--- a/src/components/createWizardForm/createWizardForm.js
+++ b/src/components/createWizardForm/createWizardForm.js
@@ -10,6 +10,7 @@ import './createWizardForm.css'
 const CreateWizardForm = (props) => {
     const {register, errors, watch, handleSubmit} = useForm({mode: 'onChange', reValidateMode: 'onChange',});
     const [showPass, setShowPass] = useState(false);
+    const [walletNameError, setNameError] = useState(false)
     const password = useRef({});
     password.current = watch("password", "");
 
@@ -17,6 +18,16 @@ const CreateWizardForm = (props) => {
 
     function onSubmit(data) {
         props.onSubmit()
+    }
+
+    const handleKeyPress = e => {
+        if(e.key.charCodeAt(0) === 46 || e.key.charCodeAt(0) === 47){
+            e.preventDefault();
+            setNameError(true)
+        }
+        else{
+            setNameError(false)
+        }
     }
 
     return (
@@ -34,13 +45,11 @@ const CreateWizardForm = (props) => {
                   <input id="Name" type="text" name="Wallet Name" placeholder="Wallet Name"
                     value={props.wizardState.wallet_name}
                     onChange={props.setStateWalletName}
-                    ref = {register({
-                        validate: value => (!value.includes('.')&&!value.includes('/') || "Certain characters prohibited from use in Wallet Name")
-                    })}
+                    onKeyPress={handleKeyPress}
                     required/>
                 </div>
                 <div className="error">
-                    {errors["Wallet Name"] && <p>{errors["Wallet Name"].message}</p>}
+                    {walletNameError && <p>Certain special characters are not permitted for use in Wallet Name</p>}
                 </div>
                 <div className="inputs-item">
                     <p>Enter a password for your wallet. Leave blank for no password.</p>

--- a/src/components/displaySeed/displaySeed.js
+++ b/src/components/displaySeed/displaySeed.js
@@ -34,7 +34,7 @@ const DisplaySeed = (props) => {
             <form>
                 {inputs}
             </form>
-            <div className="copy">
+            {/* <div className="copy">
                 <CopiedButton 
                     handleCopy={copyMnemonicToClipboard} 
                     style={{left: -65, color: '#000', textTransform: 'capitalize'}}
@@ -44,7 +44,7 @@ const DisplaySeed = (props) => {
                         <span> Copy Seed to Clipboard</span>
                     </div>
                 </CopiedButton>
-            </div>
+            </div> */}
             <div className="footer-step-btns">
                 <button onClick={onPrevStep} className="primary-btn-link back">Go Back</button>
                 <button onClick={onNextStep} className="primary-btn blue">Next</button>


### PR DESCRIPTION
Fix: Issue #454, the characters "," and "/" are not allowed in wallet name input. Error message shows if keys pressed.