### PR TITLE
Fix: Issue #474 Unconfirmed Coins Selectable in Swaps

### DIFF
--- a/src/components/coins/coins.css
+++ b/src/components/coins/coins.css
@@ -246,7 +246,7 @@
 .main-coin-wrap.no-coin {
   min-height: 50px;
 }
-.coin-item.SWAPLIMIT {
+.swap .coin-item.SWAPLIMIT, .swap .coin-item.UNCONFIRMED, .swap .coin-item.IN_MEMPOOL{
   opacity: .3;
 }
 .main-coin-wrap.small-screen .coin-item .CoinPanel {

--- a/src/components/coins/coins.js
+++ b/src/components/coins/coins.js
@@ -265,6 +265,9 @@ const Coins = (props) => {
                   dispatch(setError({ msg: 'Locktime below limit for swap participation'}))
                   return false;
                 }
+                if((item.status === STATECOIN_STATUS.IN_MEMPOOL || STATECOIN_STATUS.UNCONFIRMED) && props.swap){
+                  dispatch(setError({ msg: 'Coin unavailable for swap - awaiting confirmations' }))
+                }
                 selectCoin(item.shared_key_id)
               }}
             >


### PR DESCRIPTION
Issue #474 Fixed:
- Unconfirmed Coins appear unavailable in Swaps with hue over them
- Error message appears, "Coins unavailable for swap - awaiting confirmations"