### PR TITLE
hotfix/ ensure wallet doesn't load the dark_mode variable

### DIFF
--- a/src/features/ThemeSlice.js
+++ b/src/features/ThemeSlice.js
@@ -1,7 +1,10 @@
 import {createSlice} from '@reduxjs/toolkit'
 
+// reset dark mode
+localStorage.removeItem("dark_mode");
+
 const initialState = {
-  dark_mode: 0 //localStorage.getItem('dark_mode')
+  dark_mode: 0
 }
 
 const ThemeSlice = createSlice({


### PR DESCRIPTION
A bug occurred in the ui where if this variable is left in there, the toggle switch disappears.