### PR TITLE
FIX: Issue #595 Withdrawal Miner Fee

### DIFF
--- a/src/containers/Withdraw/Withdraw.js
+++ b/src/containers/Withdraw/Withdraw.js
@@ -99,7 +99,9 @@ const WithdrawPage = () => {
     }
   }
 
-  const handleFeeSelection = (event) => setTxFeePerKB(event.target.value)
+  const handleFeeSelection = (event) => {
+    setTxFeePerKB(event.target.value)
+  }
 
   let current_config;
   try {

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -146,7 +146,7 @@ ipcMain.on('select-backup-file', async (event, arg) => {
 });
 
 app.allowRendererProcessReuse = false;
-
+app.commandLine.appendSwitch('ignore-certificate-errors');
 // Electron Store
 const Store = require('electron-store');
 Store.initRenderer();

--- a/src/wallet/mercury/withdraw.ts
+++ b/src/wallet/mercury/withdraw.ts
@@ -84,7 +84,7 @@ export const withdraw = async (
   let txb_withdraw_unsigned;
 
   if(statecoins.length > 1) {
-      txb_withdraw_unsigned = txWithdrawBuildBatch(network, sc_infos, rec_addr, fee_info)
+      txb_withdraw_unsigned = txWithdrawBuildBatch(network, sc_infos, rec_addr, fee_info,fee_per_kb)
   } else {
       let statecoin = statecoins[0];
       let withdraw_fee = (statecoin.value * fee_info.withdraw) / 10000;


### PR DESCRIPTION
Fix Issue #595 
• Merge with server restart to ensure coins don't break
• Backup transaction fee changed to 141
• Virtual bytes used to set fee
• Maximum fee set assuming P2PKH transactions