### PR TITLE
FIX: issue#619 withdrawn and transferred coins unavailable on function pages

### DIFF
--- a/src/components/coins/FilterBy/FilterBy.css
+++ b/src/components/coins/FilterBy/FilterBy.css
@@ -66,3 +66,7 @@
 .main-coin-wrap.WITHDRAWN .filter-coin-options {
   right: 30px;
 }
+
+.swap .filter-by-wrap, .sendStatecoin .filter-by-wrap, .withdraw .filter-by-wrap{
+  display:none
+}

--- a/src/components/coins/FilterBy/FilterBy.js
+++ b/src/components/coins/FilterBy/FilterBy.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { STATECOIN_STATUS } from "../../../wallet/statecoin";
 import { updateFilter } from "../../../features/WalletDataSlice";
@@ -22,10 +22,18 @@ const FILTER_BY_OPTION = [
   },
 ];
 
-const FilterBy = () => {
+
+const FilterBy = (props) => {
   const dispatch = useDispatch();
   const [openFilterMenu, setOpenFilterMenu] = useState(false);
   const { filterBy } = useSelector((state) => state.walletData);
+
+  //Show spendable coins on page load
+  useEffect(()=> {
+    if(document.querySelector('.swap')|| document.querySelector('.withdraw')||document.querySelector('.sendStatecoin')){
+      dispatch(updateFilter("default"))
+    }
+  },[])
 
   const handleFilter = (filterBy) => {
     dispatch(updateFilter(filterBy));

--- a/src/components/coins/SortBy/SortBy.css
+++ b/src/components/coins/SortBy/SortBy.css
@@ -56,3 +56,10 @@
   height: 100vh;
   z-index: 300;
 }
+
+.swap .sort-by-menu, .sendStatecoin .sort-by-menu, .withdraw .sort-by-menu{
+  right:0;
+}
+.swap .sort-by-options, .sendStatecoin .sort-by-options, .withdraw .sort-by-options{
+  right:30px;
+}

--- a/src/components/coins/coins.js
+++ b/src/components/coins/coins.js
@@ -554,7 +554,7 @@ const Coins = (props) => {
         <div 
           className={`main-coin-wrap ${!all_coins_data.length ? 'no-coin': ''} ${filterBy} ${!props.largeScreen ? 'small-screen': ''}`}>
           <div className="sort-filter">
-            <FilterBy />
+            <FilterBy/>
             {(all_coins_data.length && filterBy !== STATECOIN_STATUS.WITHDRAWN) ? <SortBy sortCoin={sortCoin} setSortCoin={setSortCoin} /> : null }
           </div>
         {statecoinData}


### PR DESCRIPTION
FIX: Issue #619 
• Withdrawn and transferred coins no longer appear on Send, Withdraw and Swap pages
• Instead of coins being greyed out and made unavailable they have been removed entirely
