### PR TITLE
Fix: Withdraw modal exits smoothly

### DIFF
--- a/src/containers/Withdraw/Withdraw.js
+++ b/src/containers/Withdraw/Withdraw.js
@@ -93,6 +93,9 @@ const WithdrawPage = () => {
           setWithdrawTxid(res.payload)
           dispatch(setNotification({msg:"Withdraw to "+inputAddr+" Complete!"}))
         }
+        if(res.error!== undefined){
+          setOpenModal(false)
+        }
         setLoading(false)
     }))
     


### PR DESCRIPTION
Issue #660  Issue #691 

Withdraw Modal now exits smoothly if there is an error