### PR TITLE
FIX: Issue #783 Logout Swap Warning

### DIFF
--- a/src/components/ConfirmPopup/index.js
+++ b/src/components/ConfirmPopup/index.js
@@ -12,7 +12,7 @@ const ConfirmPopup = ({ children, onOk, onCancel }) => {
   const [showModal, setShowModal] = useState(false);
   const [closeText, setCloseText] = useState('Are you sure?');
   const swapRecords = useSelector(state => state.walletData.swapRecords);
-
+  
   const handleClick = () => {
     setShowModal(true);
     if(children.props.className === 'header-logout'){

--- a/src/containers/Receive/Receive.css
+++ b/src/containers/Receive/Receive.css
@@ -179,7 +179,7 @@
     color: #ffffff;
     border-radius: 5px;
     font-size:15px;
-    width:180px;
+    width:182px;
     box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.121569)
 }
 

--- a/src/containers/Swap/Swap.js
+++ b/src/containers/Swap/Swap.js
@@ -128,13 +128,16 @@ const SwapPage = () => {
             }
             if (res.payload===null) {
               dispatch(setNotification({msg:"Coin "+statecoin.getTXIdAndOut()+" removed from swap pool."}))
+              dispatch(removeCoinFromSwapRecords(selectedCoin));// added this
               setSwapLoad({...swapLoad, join: false, swapCoin:""});
               return
             }
             if (res.error===undefined) {
               dispatch(setNotification({msg:"Swap complete for coin "+ statecoin.getTXIdAndOut() +  " of value "+fromSatoshi(res.payload.value)}))
+              dispatch(removeCoinFromSwapRecords(selectedCoin));
             }else{
               dispatch(setNotification({msg:"Swap not complete for statecoin"+ statecoin.getTXIdAndOut()}));
+              dispatch(removeCoinFromSwapRecords(selectedCoin)); // Added this
               setSwapLoad({...swapLoad, join: false, swapCoin:""});
             } 
           });

--- a/src/features/WalletDataSlice.js
+++ b/src/features/WalletDataSlice.js
@@ -214,7 +214,8 @@ export const showWarning = (key) =>  {
   }
 }
 export const dontShowWarning = (key) =>  {
-  return wallet.dontShowWarning(key)
+  wallet.dontShowWarning(key)
+  return 
 }
 
 export const callGetUnconfirmedAndUnmindeCoinsFundingTxData= () => {

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -146,7 +146,7 @@ export class Wallet {
     
     new_wallet.current_sce_addr = json_wallet.current_sce_addr;
 
-    if(json_wallet.warning !== undefined) new_wallet.warnings = json_wallet.warnings
+    if(json_wallet.warnings !== undefined) new_wallet.warnings = json_wallet.warnings
     // Make sure properties added to the wallet are handled
     // New properties should not make old wallets break
 
@@ -215,7 +215,7 @@ export class Wallet {
 
   // Load wallet JSON from store
   static load(wallet_name: string, password: string, testing_mode: boolean) {
-
+    
     let store = new Storage(`wallets/${wallet_name}/config`);
     // Fetch decrypted wallet json
     let wallet_json = store.getWalletDecrypted(wallet_name, password);
@@ -412,8 +412,7 @@ export class Wallet {
   }
 
   dontShowWarning(key: string){
-    const warningObject = this.warnings.filter(w => w.name === key)
-    warningObject[0].show = false
+    this.warnings.filter(w => w.name === key)[0].show = false
     this.save()
   }
 


### PR DESCRIPTION
Fix: Issue #783 
• Swap warning only given during swap : coins remove from "swapRecords" in case of swap completion or swap failure
• Styling fix on Receive buttons with index > 100
• Warning dialogue fix