### PR TITLE
FIX: ISSUE #791 INCORRECT ADDRESS DATA

### DIFF
--- a/src/containers/Receive/Receive.js
+++ b/src/containers/Receive/Receive.js
@@ -182,7 +182,7 @@ const ReceiveStatecoinPage = () => {
 
   const usedMessage = (coin_status) => {
     if(coin_status === "SWAPPED") return "Swap"
-    if(coin_status === "IN_TRANSFER") return "Transfer"
+    // if(coin_status === "IN_TRANSFER") return "Transfer"
     if(coin_status === "AWAITING_SWAP") return "Awaiting Swap"
     if(coin_status == "INITIALISED") return "Initialised Coin"
     else return `Deposit`
@@ -277,8 +277,9 @@ const ReceiveStatecoinPage = () => {
                     {rec_sce_addr.used === true ? (
                     <span className="tooltip">
                       <div><b>Privacy Warning!</b></div>
-                      <div><b>Address Used: </b> {usedMessage(rec_sce_addr.coin_status)}</div>
-                      <div><b>Amount: </b> {rec_sce_addr.amount} BTC</div>
+                      {/* <div><b>Amount: </b> {rec_sce_addr.amount} BTC</div> */}
+                      <div><b>Last Used: </b> {usedMessage(rec_sce_addr.coin_status)}</div>
+                      <div>Address used <b>{rec_sce_addr.amount}</b> time(s)</div>
                       {/* {rec_sce_addr.txid_vout !== "" ? (<div><b>TxID-VOUT: </b> {rec_sce_addr.txid_vout}</div>):(null)} */}
                     </span>
                     ):(

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -365,41 +365,45 @@ export class Wallet {
       let coin_status = "";
       let txid_vout = "";
       let amount = 0;
+      
+      let swapped_list = []
+      // keeping a tally of the coin statechain ID prevents double counting
+
       // Get used addresses
-
-      this.statecoins.coins.map(coin => {
-
-        if(coin.sc_address === encoded_sce_address){
-          coin_status = coin.status
-          used = true
-          amount += fromSatoshi(coin.value)
-        }
+      for(let coin of this.statecoins.coins){
 
         if(coin.transfer_msg !== null){
           if(coin.transfer_msg?.rec_se_addr.tx_backup_addr == addr){
-            coin_status = coin.status
-            used = true
-            amount += fromSatoshi(coin.value)
-            txid_vout = `${coin.funding_txid}:${coin.funding_vout}`
+            coin_status = coin.status;
+            used = true;
+            amount +=1
+            txid_vout = `${coin.funding_txid}:${coin.funding_vout}`;
+            continue
           }
         }
-
+        
         if(coin.status === "SWAPPED"){
           
           if(coin.swap_transfer_msg?.rec_se_addr.tx_backup_addr == addr){
-            coin_status = coin.status
+            swapped_list.push(coin.statechain_id)
+            //add to swap list
             used = true
-            amount += fromSatoshi(coin.value)
+            // amount += fromSatoshi(coin.value)
+            amount +=1
             txid_vout = `${coin.funding_txid}:${coin.funding_vout}`
-          }
-          if(coin.sc_address === encoded_sce_address){
-            coin_status = coin.status
-            used = true
-            amount += fromSatoshi(coin.value)
-            txid_vout = `${coin.funding_txid}:${coin.funding_vout}`
+            continue
           }
         }
-      })
+
+        if(coin.sc_address === encoded_sce_address){
+          coin_status = "SWAPPED"
+          used = true
+          if(!swapped_list.includes(coin.statechain_id)) {
+            amount +=1
+            coin_status = "AVAILABLE"
+          }
+        }
+      }
       return { sce_address: encoded_sce_address, used: used, coin_status: coin_status, amount:amount, txid_vout: txid_vout}
     }
   }


### PR DESCRIPTION
• Double count in swap prevented
• IN_TRANSFER coin status used to read "Transfer" in address tooltip does no longer:
     - IN_TRANSFER coins list the address they've been sent to
     - The only scenario in which this address is also in the list of addresses on the receive page is if you send a coin to yourself
     - Best practice dictates you should create a new address before sending a coin
     -  So you send the coin to a new address
     - When you receive the coin, the coin status changes to AVAILABLE, so will no longer give the "Transfer" label
     - However the deposit address of the coin that was sent will read "Last used: Transfer"
     - This is because the coin associated with that sc_address has it's status changed to IN_TRANSFER
     - That address was used for a deposit.

• STILL IMPROVEMENTS: Can't differentiate between Deposited coins and Transferred coins