### PR TITLE
Revert the tor-adapter to call on_exit() after a timeout if a keepali…

### DIFF
--- a/tor-adapter/server/index.js
+++ b/tor-adapter/server/index.js
@@ -77,7 +77,7 @@ tor.startTorNode(tor_cmd, torrc);
 
 function close_timeout(t_secs=10) {
   return setTimeout(function () {
-    //on_exit()
+    on_exit()
   }, t_secs*1000)
 }
 
@@ -137,7 +137,7 @@ async function post_plain_endpoint(path, data, res, endpoint) {
 
 app.get('/newid', async function(req,res) {
   try{
-    timeout = restart_close_timeout(timeout)
+    timeout = restart_close_timeout(60)
     console.log("getting new tor id...")
     let response=await tor.confirmNewTorConnection();
     console.log(`got new tor id: ${JSON.stringify(response)}`)
@@ -146,24 +146,6 @@ app.get('/newid', async function(req,res) {
     res.status(400).json(err);
   }
 });
-
-app.get('/', async function(req,res) {
-  let response = {
-    tor_proxy: config.tor_proxy,
-    state_entity_endpoint: config.state_entity_endpoint,
-    swap_conductor_endpoint: config.swap_conductor_endpoint,
-    electrum_endpoint: config.electrum_endpoint
-  };
-  try{
-    timeout = restart_close_timeout(timeout)
-    let response=await tor.confirmNewTorConnection();
-    console.log(response);
-    res.status(200).json(response);
-  } catch(err) {
-    res.status(400).json(err);
-  }
-});
-
 
 app.get('/ping', async function(req,res) {
   timeout = restart_close_timeout(timeout)


### PR DESCRIPTION
…ve API call is not received. Set timeout to 60 seconds when awaiting new tor id. Remove '/' endpoint.