### PR TITLE
Feat/820 swapped coin info

### DIFF
--- a/src/components/activity/activity.css
+++ b/src/components/activity/activity.css
@@ -76,4 +76,37 @@ table span.grey {
    .table td, .table th {
       width: 100%;
    }
+   table .tooltip {
+      margin-top:45px;
+      margin-left:15%;
+   }
+
+}
+@media only screen and (min-width: 1055px) {
+   table .tooltip {
+      margin-left:5px;
+      margin-top: 1%!important;;
+   }
+}
+
+
+table .tooltip {
+   visibility: hidden;
+   width: 350px;
+   background-color: #E0E0E0;
+   color: #000000;
+   text-align: center;
+   border-radius: 6px;
+   padding: 5px 0;
+   position: absolute;
+   z-index: 1;
+   opacity: 0;
+   margin-top: 2%;
+   transition: opacity 0.3s;
+}
+
+
+table.swap-row-table:hover .tooltip {
+   visibility: visible;
+   opacity: 1;
 }

--- a/src/components/activity/activity.js
+++ b/src/components/activity/activity.js
@@ -13,15 +13,6 @@ import './activity.css';
 const Activity = () => {
     let activity_data = callGetActivityLog();
 	let statecoins = callGetAllStatecoins();
-	// FOR PULL REQUEST:
-	// • Function added to walletDataSlice to get all statecoins
-	// • Activity log FIX: now will display 10 most recent rather than 10 random
-	// • Funding TX shown in tooltip for coin before and after swap for comparison if new coin received
-	// • Tooltip for swapped activity item
-	// • button styling shadow to all buttons
-
-	//function shortens urls to fit better with styling
-
 
 	function shortenString(long){
 		let short = ""

--- a/src/components/activity/activity.js
+++ b/src/components/activity/activity.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Moment from 'react-moment';
 import { fromSatoshi } from '../../wallet/util'
-import { callGetActivityLog } from '../../features/WalletDataSlice'
+import { callGetActivityLog,callGetAllStatecoins } from '../../features/WalletDataSlice'
 import txidIcon from '../../images/txid-icon.png';
 import createIcon from '../../images/create-icon-dep.png';
 import transferIcon from '../../images/transfer-icon.png';
@@ -12,6 +12,49 @@ import './activity.css';
 
 const Activity = () => {
     let activity_data = callGetActivityLog();
+	let statecoins = callGetAllStatecoins();
+	// FOR PULL REQUEST:
+	// • Function added to walletDataSlice to get all statecoins
+	// • Activity log FIX: now will display 10 most recent rather than 10 random
+	// • Funding TX shown in tooltip for coin before and after swap for comparison if new coin received
+	// • Tooltip for swapped activity item
+	// • button styling shadow to all buttons
+
+	//function shortens urls to fit better with styling
+
+
+	function shortenString(long){
+		let short = ""
+		short = short.concat(long.slice(0,6),"...")
+		return short
+	}
+
+	function swapTxid(funding_txid, date){
+		let dateIndexArray = activity_data.filter(item => item.funding_txid === funding_txid && item.action === "S" )
+		// Filter activity for txid and swap actions
+
+		dateIndexArray = dateIndexArray.map(item => item.date).sort((a,b) => b-a)
+		//sort filtered activity by date (most recent to least recent)
+
+		let dateIndex = dateIndexArray.indexOf(date)
+		// Get index of swapped coin
+		
+		let swappedCoins = statecoins.filter(coin => coin.funding_txid === funding_txid && coin.status === "SWAPPED").sort((a,b) => a.date - b.date).reverse()
+		// Filter all statecoins for swapped TxID and sort by date (most recent to least recent)
+
+		if(swappedCoins.length > 0){
+		// Check data exists : some unforeseen error
+
+			let finalSwapData = swappedCoins[dateIndex].swap_transfer_finalized_data
+			//Get the data for the swap of coin with funding_txid
+
+			return shortenString(finalSwapData.state_chain_data.utxo.txid)
+		}
+		else{
+			return "Data not found"
+		}
+	}
+
 	if(activity_data?.length) {
 		activity_data = activity_data.sort((a, b) => {
 			return b?.date - a?.date;
@@ -32,7 +75,7 @@ const Activity = () => {
 	};
 
 	const activityDataMergeDate = mergeActivityByDate();
-    const activitiesTableData = activityDataMergeDate.map((activityGroup, groupIndex) => (
+    const activitiesTableData = activityDataMergeDate.map((activityGroup, groupIndex) =>(
         <div key={groupIndex}>
             <div className="date">
                 <Moment format="MMMM D, YYYY">{activityGroup[0]?.date}</Moment>
@@ -110,9 +153,14 @@ const Activity = () => {
 					</table>
 					: null }
 					{item.action === 'S' ?
-					<table>
+					<table className = "swap-row-table" >
+
 						<tbody>
-							<tr >
+							<span className = "tooltip" >
+								<div><b>New TxID: </b>{swapTxid(item.funding_txid,item.date)}</div>
+								<div><b>Swapped TxId: </b>{shortenString(item.funding_txid)}</div>
+							</span>
+							<tr>
 								<td>
 									<img src={withrowIcon} alt="withrowIcon"/>
 									<span className="grey"><Moment format="HH:mm A">{item.date}</Moment> </span>

--- a/src/components/panelControl/panelControl.css
+++ b/src/components/panelControl/panelControl.css
@@ -149,6 +149,10 @@
   }
   .ActionGroupRight {
     justify-content: center;
+    padding-bottom:15px;
+  }
+  .Body-button {
+    box-shadow: 0 4px 6px -6px #222;
   }
   .WalletAmount {
     justify-content: center;

--- a/src/features/WalletDataSlice.js
+++ b/src/features/WalletDataSlice.js
@@ -202,6 +202,10 @@ export const callGetBlockHeight = () => {
 export const callGetUnspentStatecoins = () => {
   return wallet.getUnspentStatecoins()
 }
+export const callGetAllStatecoins = () => {
+return wallet.getAllStatecoins()
+}
+
 export const callGetSwapGroupInfo = () => {
   return wallet.getSwapGroupInfo()
 }

--- a/src/wallet/activity_log.ts
+++ b/src/wallet/activity_log.ts
@@ -18,7 +18,7 @@ export class ActivityLog {
 
   // Return most recent items up to given depth
   getItems(depth: number) {
-    return this.items.reverse().slice(0,depth)
+    return this.items.sort((a,b) => b.date - a.date).slice(0,depth)
   }
 
   addItem(statecoin_id: string, action: string) {

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -427,6 +427,11 @@ export class Wallet {
   getUnspentStatecoins() {
     return this.statecoins.getUnspentCoins(this.block_height);
   }
+
+  getAllStatecoins(){
+    return this.statecoins.coins
+  }
+
   // Each time we get unconfirmed coins call this to check for confirmations
   checkReceivedTxStatus(unconfirmed_coins: StateCoin[]) {
     unconfirmed_coins.forEach((statecoin) => {


### PR DESCRIPTION
Issue #820: Hover data in activity list - TxID before and after swap

Explanation of functionality:
  • Activity list filtered by "S" (Swap activity) and funding TxID, then sorted by date.
  • Function added to walletDataSlice to get all statecoins
  • All statecoins filtered by SWAPPED status  and funding TxID, then sorted by date
  • Activity item matched to corresponding statecoin to get swap data
  • old funding TxID and new funding TxID shown in hover tooltip

Extra Fixes added in PR:
  • Activity log displays most recent 10 items of activity rather than random 10
  • Button shadow styling applied to all buttons
