### PR TITLE
blockheight check and fetch on deposit

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -818,6 +818,14 @@ export class Wallet {
     if (statecoin.status === STATECOIN_STATUS.AVAILABLE) throw Error("Already confirmed Coin "+statecoin.getTXIdAndOut()+".");
     if (statecoin.status === STATECOIN_STATUS.INITIALISED) throw Error("Awaiting funding transaction for StateCoin "+statecoin.getTXIdAndOut()+".");
 
+    // check that blockheight is recent
+    // if not, update it
+    if (this.block_height < 709862) {
+      let header = await this.electrum_client.latestBlockHeader();
+      this.setBlockHeight(header);
+    }
+    if (this.block_height < 709862) throw Error("Block height not updated");
+
     let statecoin_finalized = await depositConfirm(
       this.http_client,
       await this.getWasm(),


### PR DESCRIPTION
On deposit confirm, check that the the current blockheight is reasonable (not zero, which can result from a failed getblockheight call earlier). If not, try to fetch it again, then throw error. 