### PR TITLE
Kill existing tor adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "react-app-rewired test --env=jsdom",
     "test-node": "react-app-rewired test --env=node",
     "eject": "react-scripts eject",
-    "electron": "electron --inspect=5858 --testnet .",
+    "electron": "electron --inspect=5858 --testnet --term_existing .",
     "dev": "BROWSER=none nf start -p 3000",
     "postinstall": "electron-builder install-app-deps",
     "build-wasm": "wasm-pack build --dev client-wasm",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "postinstall": "electron-builder install-app-deps",
     "build-wasm": "wasm-pack build --dev client-wasm",
     "app-windows": "yarn install-local && yarn install && yarn build && electron-builder -w -p always",
+    "app-windows-local-test": "yarn install-local && yarn install && yarn build && DEBUG=electron-builder electron-builder -w -p never",
     "app-linux": "yarn install-local && yarn install && yarn build && electron-builder -l AppImage -p always",
     "app-linux-local-test": "yarn install-local && yarn install && yarn build && DEBUG=electron-builder electron-builder -l AppImage -p never",
     "app-macos": "yarn install-local && yarn install && yarn build && electron-builder -m -p always",

--- a/public/electron.js
+++ b/public/electron.js
@@ -115,12 +115,17 @@ async function getTorAdapter(path) {
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
   //Limit app to one instance
-  if(!app.requestSingleInstanceLock() && getPlatform() !== 'win'){
+  if(!app.requestSingleInstanceLock()){
       alert('mercurywallet is already running. Not opening app.')
       app.quit()
     } 
   
-  terminate_mercurywallet_process(init_tor_adapter);
+    if(getPlatform() !== 'win'){
+      terminate_mercurywallet_process(init_tor_adapter);
+    } else {
+      init_tor_adapter()
+    }
+  
   createWindow()
   }
 );
@@ -312,7 +317,9 @@ async function on_exit(){
 
 async function kill_tor(){
   console.log("terminating the tor adapter process...")
-  await kill_process(ta_process.pid)
+  if(ta_process){
+    await kill_process(ta_process.pid)
+  }
 }
 
 async function kill_process(pid, init_new){

--- a/public/electron.js
+++ b/public/electron.js
@@ -219,7 +219,7 @@ function terminate_mercurywallet_process(init_new) {
       return
     }
   
-    let pids=null
+    let pid=null
     //Split by new line
     const pid_arr = stdout.split(/\r\n|\n\r|\n|\r/)
     //If windows check this is not the current process or one of its child processes

--- a/public/electron.js
+++ b/public/electron.js
@@ -115,7 +115,7 @@ async function getTorAdapter(path) {
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
   //Limit app to one instance
-  if(!app.requestSingleInstanceLock()){
+  if(!app.requestSingleInstanceLock() && getPlatform() !== 'win'){
       alert('mercurywallet is already running. Not opening app.')
       app.quit()
     } 
@@ -312,9 +312,7 @@ async function on_exit(){
 
 async function kill_tor(){
   console.log("terminating the tor adapter process...")
-  if(ta_process){
-    await kill_process(ta_process.pid)
-  }
+  await kill_process(ta_process.pid)
 }
 
 async function kill_process(pid, init_new){

--- a/public/electron.js
+++ b/public/electron.js
@@ -120,12 +120,7 @@ app.on('ready', () => {
       app.quit()
     } 
   
-    if(getPlatform() !== 'win'){
-      terminate_mercurywallet_process(init_tor_adapter);
-    } else {
-      init_tor_adapter()
-    }
-  
+  terminate_mercurywallet_process(init_tor_adapter);
   createWindow()
   }
 );

--- a/public/electron.js
+++ b/public/electron.js
@@ -5,7 +5,6 @@ const url = require('url');
 const fs = require('fs');
 const fixPath = require('fix-path');
 const alert = require('alert');
-const confirm = require('confirm');
 const rootPath = require('electron-root-path').rootPath;
 const axios = require('axios').default;
 const process = require('process')
@@ -117,19 +116,10 @@ async function getTorAdapter(path) {
 app.on('ready', () => {
   //Limit app to one instance
   if(!app.requestSingleInstanceLock()){
-    let bconfirm=false
-    if(getPlatform() == 'win'){
-      bconfirm = confirm("An instance of mercurywallet is already running. Close the existing mercurywallet process?")
-    } else {
-      alert('An instance of mercurywallet is already running. Not opening app.')
-    }
-
-    if(!bconfirm){
+      alert('mercurywallet is already running. Not opening app.')
       app.quit()
     } 
-  }
-
-    
+  
   terminate_mercurywallet_process(init_tor_adapter);
   createWindow()
   }

--- a/public/electron.js
+++ b/public/electron.js
@@ -115,7 +115,7 @@ async function getTorAdapter(path) {
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
   //Limit app to one instance
-  if(!app.requestSingleInstanceLock()){
+  if(!app.requestSingleInstanceLock() && getPlatform() !== 'win'){
       alert('mercurywallet is already running. Not opening app.')
       app.quit()
     } 

--- a/public/electron.js
+++ b/public/electron.js
@@ -215,10 +215,8 @@ function terminate_mercurywallet_process(init_new) {
   let command
   if(getPlatform() === 'win'){
     command = 'wmic process where name=\'mercurywallet.exe\' get ParentProcessId,ProcessId'
-  } else if(getPlatform() === 'mac') {
-    command = 'ps axo pid,ppid,command | grep mercurywallet.app | grep tor | grep -v grep'
   } else {
-    command = 'ps axo pid,ppid,command | grep mercurywallet | grep tor | grep -v grep'
+    command = 'ps axo \"pid,ppid,command\" | grep mercury | grep tor | grep -v grep'
   }
   exec(command, (error, stdout, stderr) => {
     if(error) {

--- a/public/electron.js
+++ b/public/electron.js
@@ -5,6 +5,7 @@ const url = require('url');
 const fs = require('fs');
 const fixPath = require('fix-path');
 const alert = require('alert');
+const confirm = require('confirm');
 const rootPath = require('electron-root-path').rootPath;
 const axios = require('axios').default;
 const process = require('process')
@@ -123,7 +124,7 @@ app.on('ready', () => {
       alert('An instance of mercurywallet is already running. Not opening app.')
     }
 
-    if(!confirm){
+    if(!bconfirm){
       app.quit()
     } 
   }

--- a/public/electron.js
+++ b/public/electron.js
@@ -246,10 +246,8 @@ async function kill_process(pid, init_new){
     //check if still running
     process.kill(pid, 0)
     //if still running wait, check again and send the kill signal
-    console.log("process still running - waiting 1 second...")
     await new Promise(resolve => setTimeout(resolve, 1000))
     process.kill(pid, 0)
-    console.log("process still running - waiting 1 second...")
     await new Promise(resolve => setTimeout(resolve, 1000))
     process.kill(pid, 0)
     console.log("process still running - sending kill signal...")

--- a/public/electron.js
+++ b/public/electron.js
@@ -207,11 +207,12 @@ function terminate_mercurywallet_process(init_new) {
   if(getPlatform() === 'win'){
     command = 'wmic process where name=\'mercurywallet.exe\' get ParentProcessId,ProcessId'
   } else {
-    command = 'ps axo \"pid,ppid,command\" | grep mercury | grep tor | grep -v grep'
+    command = 'echo `ps axo \"pid,ppid,command\" | grep mercury | grep tor | grep -v grep`'
   }
   exec(command, (error, stdout, stderr) => {
     if(error) {
       console.error(`terminate_mercurywallet_process- exec error: ${error}`)
+      console.log(`terminate_mercurywallet_process- exec error: ${error}`)
       return
     }
     if(stderr){
@@ -236,10 +237,12 @@ function terminate_mercurywallet_process(init_new) {
       }
     } else {
       pid_str=pid_arr[0].trim().replace(/\s+/g,' ').split(' ')[0]
-      pid=parseInt(pid_str)
+      if(pid_str){
+        pid=parseInt(pid_str)
+      }
     }
 
-    if(typeof pid === 'number'){
+    if(pid){
       console.log(`terminating existing mercurywallet process: ${pid}`)
       kill_process(pid, init_new)
       return
@@ -249,6 +252,59 @@ function terminate_mercurywallet_process(init_new) {
     return  
   })
 }
+  
+// Terminate the parent process of any running mercurywallet processes.
+function terminate_mercurywallet_process(init_new) {
+  let command
+  if(getPlatform() === 'win'){
+    command = 'wmic process where name=\'mercurywallet.exe\' get ParentProcessId,ProcessId'
+  } else {
+    command = 'echo `ps axo \"pid,ppid,command\" | grep mercury | grep tor | grep -v grep`'
+  }
+  exec(command, (error, stdout, stderr) => {
+    if(error) {
+      console.error(`terminate_mercurywallet_process- exec error: ${error}`)
+      console.log(`terminate_mercurywallet_process- exec error: ${error}`)
+      return
+    }
+    if(stderr){
+      console.log(`terminate_mercurywallet_process- error: ${stderr}`)
+      return
+    }
+  
+    let pid=null
+    //Split by new line
+    const pid_arr = stdout.split(/\r\n|\n\r|\n|\r/)
+    //If windows check this is not the current process or one of its child processes
+    if(getPlatform() === 'win'){
+      for(i=1; i<pid_arr.length; i++){
+        const tmp_arr = pid_arr[i].trim().replace(/\s+/g,' ').split(' ')
+        const ppid = parseInt(tmp_arr[0])
+        pid = ParseInt(tmp_arr[1])
+        if (ppid !== process.pid && pid !== process.pid) {
+          break;
+        } else {
+          pid=null
+        }
+      }
+    } else {
+      pid_str=pid_arr[0].trim().replace(/\s+/g,' ').split(' ')[0]
+      if(pid_str){
+        pid=parseInt(pid_str)
+      }
+    }
+
+    if(pid){
+      console.log(`terminating existing mercurywallet process: ${pid}`)
+      kill_process(pid, init_new)
+      return
+    } 
+
+    init_new()
+    return  
+  })
+}
+  
 
 async function on_exit(){
   await kill_tor();

--- a/public/electron.js
+++ b/public/electron.js
@@ -114,14 +114,14 @@ async function getTorAdapter(path) {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
-  //Limit app to one instance
-  if(!app.requestSingleInstanceLock() && getPlatform() !== 'win'){
+    //Limit app to one instance
+    if(!app.requestSingleInstanceLock() && !(term_existing && getPlatform() === 'win') ){
       alert('mercurywallet is already running. Not opening app.')
       app.quit()
-    } 
+    }
   
-  terminate_mercurywallet_process(init_tor_adapter);
-  createWindow()
+    terminate_mercurywallet_process(init_tor_adapter);
+    createWindow()
   }
 );
 
@@ -311,8 +311,10 @@ async function on_exit(){
 }
 
 async function kill_tor(){
-  console.log("terminating the tor adapter process...")
-  await kill_process(ta_process.pid)
+  if(ta_process){
+    console.log("terminating the tor adapter process...")
+    await kill_process(ta_process.pid)
+  }
 }
 
 async function kill_process(pid, init_new){

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -6,6 +6,7 @@ SendStatecoinPage, ReceiveStatecoinPage, SwapPage, BackupTxPage, LoadWalletPage,
 import { getWalletName } from '../../features/WalletDataSlice';
 import { Header } from '../../components'
 
+
 import './App.css';
 import './AppDarkMode.css';
 
@@ -27,7 +28,7 @@ const App = () => {
   }, [dark_mode]);
   return (
     <div className={`App ${dark_mode === '1' ? 'dark-mode': ''}`}>
-      {walletLoaded ? <title>Mercury Wallet - {walletName}</title> : <title>Mercury Wallet</title>}
+      {walletLoaded ? <title>{app.getName()} {app.getVersion()} - {walletName}</title> : <title>{app.getName()} {app.getVersion()}</title>}
       <Router>
       <Header walletLoaded={walletLoaded} setWalletLoaded={setWalletLoaded} />
       <Switch>

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -28,7 +28,7 @@ const App = () => {
   }, [dark_mode]);
   return (
     <div className={`App ${dark_mode === '1' ? 'dark-mode': ''}`}>
-      {walletLoaded ? <title>{app.getName()} {app.getVersion()} - {walletName}</title> : <title>{app.getName()} {app.getVersion()}</title>}
+      {walletLoaded ? <title>Mercury Wallet - {walletName}</title> : <title>Mercury Wallet</title>}
       <Router>
       <Header walletLoaded={walletLoaded} setWalletLoaded={setWalletLoaded} />
       <Switch>

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -6,6 +6,7 @@ const path = require('path');
 const url = require('url');
 const fixPath = require('fix-path');
 const alert = require('alert');
+const confirm = require('confirm');
 const rootPath = require('electron-root-path').rootPath;
 const axios = require('axios').default;
 const process = require('process')
@@ -111,21 +112,20 @@ async function getTorAdapter(path) {
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
   //Limit app to one instance
+  
   if(!app.requestSingleInstanceLock()){
     let bconfirm=false
-    if(getPlatform() == 'win'){
+    if(getPlatform() === 'win'){
       bconfirm = confirm("An instance of mercurywallet is already running. Close the existing mercurywallet process?")
     } else {
       alert('An instance of mercurywallet is already running. Not opening app.')
     }
-
-    if(!confirm){
+    if(!bconfirm){
       app.quit()
     } 
   }
 
-    
-  terminate_mercurywallet_process(init_tor_adapter);
+  terminate_mercurywallet_process(init_tor_adapter)
   createWindow()
   }
 );

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -117,7 +117,12 @@ app.on('ready', () => {
     app.quit()
   }
 
-  terminate_mercurywallet_process(init_tor_adapter);
+  if(getPlatform() !== 'win'){
+    terminate_mercurywallet_process(init_tor_adapter);
+  } else {
+    init_tor_adapter()
+  }
+
   createWindow()
   }
 );
@@ -260,9 +265,7 @@ async function on_exit(){
 
 async function kill_tor(){
     console.log("terminating the tor adapter process...")
-    if(ta_process){
-      await kill_process(ta_process.pid)
-    }
+    await kill_process(ta_process.pid)
 }
 
 async function kill_process(pid, init_new){

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -219,7 +219,7 @@ function terminate_mercurywallet_process(init_new) {
       return
     }
   
-    let pids=null
+    let pid=null
     //Split by new line
     const pid_arr = stdout.split(/\r\n|\n\r|\n|\r/)
     //If windows check this is not the current process or one of its child processes

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -249,10 +249,8 @@ async function kill_process(pid, init_new){
     //check if still running
     process.kill(pid, 0)
     //if still running wait, check again and send the kill signal
-    console.log("process still running - waiting 1 second...")
     await new Promise(resolve => setTimeout(resolve, 1000))
     process.kill(pid, 0)
-    console.log("process still running - waiting 1 second...")
     await new Promise(resolve => setTimeout(resolve, 1000))
     process.kill(pid, 0)
     console.log("process still running - sending kill signal...")

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -6,7 +6,6 @@ const path = require('path');
 const url = require('url');
 const fixPath = require('fix-path');
 const alert = require('alert');
-const confirm = require('confirm');
 const rootPath = require('electron-root-path').rootPath;
 const axios = require('axios').default;
 const process = require('process')
@@ -112,17 +111,9 @@ async function getTorAdapter(path) {
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
   //Limit app to one instance
-  
   if(!app.requestSingleInstanceLock()){
-    let bconfirm=false
-    if(getPlatform() === 'win'){
-      bconfirm = confirm("An instance of mercurywallet is already running. Close the existing mercurywallet process?")
-    } else {
-      alert('An instance of mercurywallet is already running. Not opening app.')
-    }
-    if(!bconfirm){
-      app.quit()
-    } 
+    alert('mercurywallet is already running. Not opening app.')
+    app.quit()
   }
 
   terminate_mercurywallet_process(init_tor_adapter)

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -112,12 +112,17 @@ async function getTorAdapter(path) {
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
   //Limit app to one instance
-  if(!app.requestSingleInstanceLock() && getPlatform() !== 'win' ){
+  if(!app.requestSingleInstanceLock()){
     alert('mercurywallet is already running. Not opening app.')
     app.quit()
   }
 
-  terminate_mercurywallet_process(init_tor_adapter)
+  if(getPlatform() !== 'win'){
+    terminate_mercurywallet_process(init_tor_adapter);
+  } else {
+    init_tor_adapter()
+  }
+
   createWindow()
   }
 );
@@ -260,7 +265,9 @@ async function on_exit(){
 
 async function kill_tor(){
     console.log("terminating the tor adapter process...")
-    await kill_process(ta_process.pid)
+    if(ta_process){
+      await kill_process(ta_process.pid)
+    }
 }
 
 async function kill_process(pid, init_new){

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -11,6 +11,7 @@ const axios = require('axios').default;
 const process = require('process')
 const fork = require('child_process').fork;
 const exec = require('child_process').exec;
+const execFile = require('child_process').execFile;
 
 const getPlatform = () => {
   switch (process.platform) {
@@ -207,11 +208,12 @@ function terminate_mercurywallet_process(init_new) {
   if(getPlatform() === 'win'){
     command = 'wmic process where name=\'mercurywallet.exe\' get ParentProcessId,ProcessId'
   } else {
-    command = 'ps axo \"pid,ppid,command\" | grep mercury-wallet | grep tor | grep -v grep'
+    command = 'echo `ps axo \"pid,ppid,command\" | grep mercury | grep tor | grep -v grep`'
   }
   exec(command, (error, stdout, stderr) => {
     if(error) {
       console.error(`terminate_mercurywallet_process- exec error: ${error}`)
+      console.log(`terminate_mercurywallet_process- exec error: ${error}`)
       return
     }
     if(stderr){
@@ -236,10 +238,12 @@ function terminate_mercurywallet_process(init_new) {
       }
     } else {
       pid_str=pid_arr[0].trim().replace(/\s+/g,' ').split(' ')[0]
-      pid=parseInt(pid_str)
+      if(pid_str){
+        pid=parseInt(pid_str)
+      }
     }
 
-    if(typeof pid === 'number'){
+    if(pid){
       console.log(`terminating existing mercurywallet process: ${pid}`)
       kill_process(pid, init_new)
       return

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -112,7 +112,7 @@ async function getTorAdapter(path) {
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
   //Limit app to one instance
-  if(!app.requestSingleInstanceLock()){
+  if(!app.requestSingleInstanceLock() && getPlatform() !== 'win' ){
     alert('mercurywallet is already running. Not opening app.')
     app.quit()
   }

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -43,6 +43,13 @@ torrc = joinPath(resourcesPath, 'etc', 'torrc');
 
 const tor_cmd = (getPlatform() === 'win') ? `${joinPath(execPath, 'Tor', 'tor')}`: `${joinPath(execPath, 'tor')}`;
 
+let term_existing = false;
+for(let i=0; i<process.argv.length;i++){
+  if (process.argv[i].includes('term_existing')){
+    term_existing=true
+  }
+}
+
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow;
@@ -112,17 +119,12 @@ async function getTorAdapter(path) {
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
   //Limit app to one instance
-  if(!app.requestSingleInstanceLock()){
+  if(!app.requestSingleInstanceLock() && !(term_existing && getPlatform() === 'win') ){
     alert('mercurywallet is already running. Not opening app.')
     app.quit()
   }
 
-  if(getPlatform() !== 'win'){
-    terminate_mercurywallet_process(init_tor_adapter);
-  } else {
-    init_tor_adapter()
-  }
-
+  terminate_mercurywallet_process(init_tor_adapter);
   createWindow()
   }
 );
@@ -265,7 +267,9 @@ async function on_exit(){
 
 async function kill_tor(){
     console.log("terminating the tor adapter process...")
-    await kill_process(ta_process.pid)
+    if(ta_process){
+      await kill_process(ta_process.pid)
+    }
 }
 
 async function kill_process(pid, init_new){

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -117,12 +117,8 @@ app.on('ready', () => {
     app.quit();
   }
 
-  if(getPlatform() === 'linux' || getPlatform() === 'mac'){
-    kill_existing_tor_adapter(init_tor_adapter);
-  } else {
-    init_tor_adapter()
-  }
-  
+  kill_existing_tor_adapter(init_tor_adapter);
+ 
   createWindow(); 
 });
 
@@ -209,7 +205,12 @@ async function init_tor_adapter(){
 }
 
 function kill_existing_tor_adapter(init_new) {
-  let command = 'ps ux | grep mercury-wallet | grep -v grep | grep tor-adapter | awk -F \' \' \'{print $2}\''
+  let command
+  if(getPlatform() === 'win'){
+    command = 'wmic process where name=\'mercurywallet.exe\' get ProcessId'
+  } else {
+    command = 'ps ux | grep mercury-wallet | grep -v grep | grep tor-adapter | awk -F \' \' \'{print $2}\''
+  }
   exec(command, (error, stdout, stderr) => {
     if(error) {
       console.error(`kill_existing_tor_adapter - exec error: ${error}`)

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -64,7 +64,7 @@ function createWindow() {
     if (process.platform !== 'darwin') {
       mainWindow.setMenu(null);
     }
-    
+
     // Open links in systems default browser
     mainWindow.webContents.on('new-window', function(e, url) {
       e.preventDefault();
@@ -110,17 +110,25 @@ async function getTorAdapter(path) {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.on('ready', () => {
-
   //Limit app to one instance
   if(!app.requestSingleInstanceLock()){
-    alert("Cannot start mercury wallet - an instance of the app is already running.")
-    app.quit();
+    let bconfirm=false
+    if(getPlatform() == 'win'){
+      bconfirm = confirm("An instance of mercurywallet is already running. Close the existing mercurywallet process?")
+    } else {
+      alert('An instance of mercurywallet is already running. Not opening app.')
+    }
+
+    if(!confirm){
+      app.quit()
+    } 
   }
 
+    
   terminate_mercurywallet_process(init_tor_adapter);
- 
-  createWindow(); 
-});
+  createWindow()
+  }
+);
 
 // Quit when all windows are closed.
 app.on('window-all-closed', async function () {
@@ -206,11 +214,11 @@ async function init_tor_adapter(){
 function terminate_mercurywallet_process(init_new) {
   let command
   if(getPlatform() === 'win'){
-    command = 'wmic process where name=\'mercurywallet.exe\' get ProcessId'
+    command = 'wmic process where name=\'mercurywallet.exe\' get ParentProcessId,ProcessId'
   } else if(getPlatform() === 'mac') {
-    command = 'ps ux | grep mercurywallet.app | awk -F \' \' \'{print $2}\''
+    command = 'ps axo pid,ppid,command | grep mercury-wallet | grep tor | grep -v grep'
   } else {
-    command = 'ps ux | grep mercurywallet | awk -F \' \' \'{print $2}\''
+    command = 'ps axo pid,ppid,command | grep mercury-wallet | grep tor | grep -v grep'
   }
   exec(command, (error, stdout, stderr) => {
     if(error) {
@@ -221,15 +229,33 @@ function terminate_mercurywallet_process(init_new) {
       console.log(`terminate_mercurywallet_process- error: ${stderr}`)
       return
     }
-    const pid_str = stdout.split('\r\n|\n\r|\n|\r')[0]
-    if(pid_str.match(/^[0-9]+$/) != null){
-      const pid = parseInt(stdout)
-      if(typeof pid === 'number'){
-        console.log(`terminating existing mercurywallet process: ${pid}`)
-        kill_process(pid, init_new)
-        return
-      } 
+  
+    let pids=null
+    //Split by new line
+    const pid_arr = stdout.split(/\r\n|\n\r|\n|\r/)
+    //If windows check this is not the current process or one of its child processes
+    if(getPlatform() === 'win'){
+      for(i=1; i<pid_arr.length; i++){
+        const tmp_arr = pid_arr[i].trim().replace(/\s+/g,' ').split(' ')
+        const ppid = parseInt(tmp_arr[0])
+        pid = ParseInt(tmp_arr[1])
+        if (ppid !== process.pid && pid !== process.pid) {
+          break;
+        } else {
+          pid=null
+        }
+      }
+    } else {
+      pid_str=pid_arr[0].trim().replace(/\s+/g,' ').split(' ')[0]
+      pid=parseInt(pid_str)
     }
+
+    if(typeof pid === 'number'){
+      console.log(`terminating existing mercurywallet process: ${pid}`)
+      kill_process(pid, init_new)
+      return
+    } 
+
     init_new()
     return  
   })

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -117,12 +117,7 @@ app.on('ready', () => {
     app.quit()
   }
 
-  if(getPlatform() !== 'win'){
-    terminate_mercurywallet_process(init_tor_adapter);
-  } else {
-    init_tor_adapter()
-  }
-
+  terminate_mercurywallet_process(init_tor_adapter);
   createWindow()
   }
 );

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -215,10 +215,8 @@ function terminate_mercurywallet_process(init_new) {
   let command
   if(getPlatform() === 'win'){
     command = 'wmic process where name=\'mercurywallet.exe\' get ParentProcessId,ProcessId'
-  } else if(getPlatform() === 'mac') {
-    command = 'ps axo pid,ppid,command | grep mercury-wallet | grep tor | grep -v grep'
   } else {
-    command = 'ps axo pid,ppid,command | grep mercury-wallet | grep tor | grep -v grep'
+    command = 'ps axo \"pid,ppid,command\" | grep mercury-wallet | grep tor | grep -v grep'
   }
   exec(command, (error, stdout, stderr) => {
     if(error) {

--- a/src/wallet/recovery.ts
+++ b/src/wallet/recovery.ts
@@ -9,8 +9,7 @@ let cloneDeep = require('lodash.clonedeep');
 
 // number of keys to generate per recovery call. If no statecoins are found for this number
 // of keys then assume there are no more statecoins owned by this wallet.
-const NUM_KEYS_PER_RECOVERY_ATTEMPT = 100;
-const TOTAL_NUM_KEYS = 900;
+const NUM_KEYS_PER_RECOVERY_ATTEMPT = 250;
 
 // Send all proof keys to server to check for statecoins owned by this wallet.
 // Should be used as a last resort only due to privacy leakage.
@@ -24,15 +23,12 @@ export const recoverCoins = async (wallet: Wallet): Promise<RecoveryDataMsg[]> =
   addrs.push(addr);
   recovery_request.push({key: wallet.account.derive(addr).publicKey.toString("hex"), sig: ""});
   // Keep grabbing data until NUM_KEYS_PER_RECOVERY_ATTEMPT keys have no statecoins
-  let total_keys=0
-  while (total_keys < TOTAL_NUM_KEYS || new_recovery_data_load.length > 0) {
+  while (new_recovery_data_load.length > 0) {
     for (let i=0; i<NUM_KEYS_PER_RECOVERY_ATTEMPT; i++) {
       let addr = wallet.account.nextChainAddress(0);
       addrs.push(addr);
       recovery_request.push({key: wallet.account.derive(addr).publicKey.toString("hex"), sig: ""});
     }
-    total_keys = total_keys + NUM_KEYS_PER_RECOVERY_ATTEMPT
-    console.log(`get keys up to ${total_keys}`)
     new_recovery_data_load = await getRecoveryRequest(wallet.http_client, recovery_request);
     recovery_request = [];
     recovery_data = recovery_data.concat(new_recovery_data_load);

--- a/src/wallet/recovery.ts
+++ b/src/wallet/recovery.ts
@@ -9,7 +9,8 @@ let cloneDeep = require('lodash.clonedeep');
 
 // number of keys to generate per recovery call. If no statecoins are found for this number
 // of keys then assume there are no more statecoins owned by this wallet.
-const NUM_KEYS_PER_RECOVERY_ATTEMPT = 25;
+const NUM_KEYS_PER_RECOVERY_ATTEMPT = 100;
+const TOTAL_NUM_KEYS = 900;
 
 // Send all proof keys to server to check for statecoins owned by this wallet.
 // Should be used as a last resort only due to privacy leakage.
@@ -23,12 +24,15 @@ export const recoverCoins = async (wallet: Wallet): Promise<RecoveryDataMsg[]> =
   addrs.push(addr);
   recovery_request.push({key: wallet.account.derive(addr).publicKey.toString("hex"), sig: ""});
   // Keep grabbing data until NUM_KEYS_PER_RECOVERY_ATTEMPT keys have no statecoins
-  while (new_recovery_data_load.length > 0) {
+  let total_keys=0
+  while (total_keys < TOTAL_NUM_KEYS || new_recovery_data_load.length > 0) {
     for (let i=0; i<NUM_KEYS_PER_RECOVERY_ATTEMPT; i++) {
       let addr = wallet.account.nextChainAddress(0);
       addrs.push(addr);
       recovery_request.push({key: wallet.account.derive(addr).publicKey.toString("hex"), sig: ""});
     }
+    total_keys = total_keys + NUM_KEYS_PER_RECOVERY_ATTEMPT
+    console.log(`get keys up to ${total_keys}`)
     new_recovery_data_load = await getRecoveryRequest(wallet.http_client, recovery_request);
     recovery_request = [];
     recovery_data = recovery_data.concat(new_recovery_data_load);

--- a/tor-adapter/package.json
+++ b/tor-adapter/package.json
@@ -14,7 +14,6 @@
     "winston": "^3.3.3",
     "async-mutex": "^0.3.2",
     "axios": "^0.21.1",
-    "bitcoinjs-lib": "^5.2.0",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "default-shell": "^1.0.1",

--- a/tor-adapter/server/index.js
+++ b/tor-adapter/server/index.js
@@ -245,6 +245,7 @@ process.once('SIGTERM', async function (code) {
   await shutdown()
 });
 
+
 async function shutdown() {
   try{
     await tor.stopTorNode();

--- a/tor-adapter/server/index.js
+++ b/tor-adapter/server/index.js
@@ -235,24 +235,25 @@ app.get('/tor_endpoints', function(req,res) {
   res.status(200).json(response);
 });
 
-app.get('/tor_adapter/shutdown', async function(req,res) {
-  try {
-    let response = await tor.stopTorNode();
-    res.status(200).json(response);
-    process.exit();
-  } catch (err) {
-    res.status(400).json(`Shutdown failed: ${err}`);
-  }
+process.once('SIGINT', async function (code) {
+  console.log('SIGINT received...');
+  await shutdown()
 });
 
-app.get('/tor_adapter/shutdown/tor', async function(req,res) {
-  try {
-    let response = await tor.stopTorNode();
-    res.status(200).json(response);
-  } catch (err) {
-    res.status(400).json(`Shutdown failed: ${err}`);
-  }
+process.once('SIGTERM', async function (code) {
+  console.log('SIGTERM received...');
+  await shutdown()
 });
+
+async function shutdown() {
+  try{
+    await tor.stopTorNode();
+  } catch (err) {
+    console.log('error stopping to node - sending the kill signal...');
+    tor.kill_proc()
+  }
+  process.exit(0);
+}
 
 app.get('/electrs/*', function(req,res) {
   let path = req.path.replace('\/electrs','')


### PR DESCRIPTION
- Cleanly terminate the tor-adapter and tor node processes on shutdown (the tor adapter now shuts down the tor node on SIGINT or SIGTERM signals by sending SIGTERM to the tor node and, if that fails, SIGKILL).
- Terminate the tor adapter process on startup, if running (on windows, kill the parent mercurywallet.exe process)