### PR TITLE
Correct the logic for showing the "previously deposited" warning mess…

### DIFF
--- a/src/containers/Swap/Swap.js
+++ b/src/containers/Swap/Swap.js
@@ -133,7 +133,7 @@ const SwapPage = () => {
               return
             }
             if (res.error===undefined) {
-              if(statecoin.is_deposited){
+              if(res.payload?.is_deposited){
                 dispatch(setNotification({msg:"Warning - received coin in swap that was previously deposited in this wallet: "+ statecoin.getTXIdAndOut() +  " of value "+fromSatoshi(res.payload.value)}))
                 dispatch(removeCoinFromSwapRecords(selectedCoin));
               } else {


### PR DESCRIPTION
…age after swap completion.

The message warning the user that the coin received in the swap was original to the wallet was being displayed for every transfer - the wrong variable was being used to determine this.