### PR TITLE
keep locktime for replacement txs

### DIFF
--- a/src/wallet/mercury/deposit.ts
+++ b/src/wallet/mercury/deposit.ts
@@ -64,11 +64,9 @@ export const depositConfirm = async (
 
   // Calculate initial locktime
   let init_locktime = (chaintip_height) + (fee_info.initlock);
-  console.log(init_locktime);
   // if previously set (RBF) use initial height
   if (statecoin.init_locktime) {
     init_locktime = statecoin.init_locktime;
-    console.log(init_locktime);
   } else {
     statecoin.init_locktime = init_locktime;
   }

--- a/src/wallet/mercury/deposit.ts
+++ b/src/wallet/mercury/deposit.ts
@@ -64,6 +64,14 @@ export const depositConfirm = async (
 
   // Calculate initial locktime
   let init_locktime = (chaintip_height) + (fee_info.initlock);
+  console.log(init_locktime);
+  // if previously set (RBF) use initial height
+  if (statecoin.init_locktime) {
+    init_locktime = statecoin.init_locktime;
+    console.log(init_locktime);
+  } else {
+    statecoin.init_locktime = init_locktime;
+  }
 
   // Build unsigned backup tx
   let backup_receive_addr = pubKeyTobtcAddr(statecoin.proof_key, network);

--- a/src/wallet/statecoin.ts
+++ b/src/wallet/statecoin.ts
@@ -356,6 +356,7 @@ export class StateCoin {
   tx_backup: BTCTransaction | null;
   backup_status: string;
   backup_confirm: boolean;
+  init_locktime: number | null;
   interval: number;
   tx_cpfp: BTCTransaction | null;
   tx_withdraw: BTCTransaction | null;
@@ -405,6 +406,7 @@ export class StateCoin {
     this.tx_backup = null;
     this.backup_status = BACKUP_STATUS.PRE_LOCKTIME;
     this.backup_confirm = false;
+    this.init_locktime = null;
     this.interval = 1;
     this.tx_cpfp = null;
     this.tx_withdraw = null;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -813,17 +813,18 @@ export class Wallet {
           let statecoin = this.statecoins.getCoin(shared_key_id);
           statecoin!.value = funding_tx_data[i].value;
         }
-        if (!funding_tx_data[i].height) {
-          log.info("Found funding tx for p_addr "+p_addr+" in mempool. txid: "+funding_tx_data[i].tx_hash)
-          // check if coin txid has changed (due to RBF)
-          let coin = this.statecoins.getCoin(shared_key_id);
+        // check if coin txid has changed (due to RBF)
+        let coin = this.statecoins.getCoin(shared_key_id);
+        if (coin!.backup_confirm) {
           if (coin) {
             if (coin.funding_txid != funding_tx_data[i].tx_hash && coin.value == funding_tx_data[i].value) {
-              console.log("RBF tx replacement");
               coin.tx_backup = null;
               coin.backup_confirm = false;
             }
           }
+        }
+        if (!funding_tx_data[i].height) {
+          log.info("Found funding tx for p_addr "+p_addr+" in mempool. txid: "+funding_tx_data[i].tx_hash)
           this.statecoins.setCoinInMempool(shared_key_id, funding_tx_data[i])
           this.saveStateCoinsList()
         } else {


### PR DESCRIPTION
Keep the same locktime for subsequent deposit backup txs in case of replacement. 
This will also be enforced by the server. 