### PR TITLE
Feat/transfer sender api update

### DIFF
--- a/src/settings.json
+++ b/src/settings.json
@@ -1,6 +1,6 @@
 {
   "min_anon_set": 5,
-  "testing_mode": false,
+  "testing_mode": true,
   "required_confirmations": 3,
   "tor_proxy": {"ip": "localhost",
     "port": 9060,

--- a/src/wallet/http_client.ts
+++ b/src/wallet/http_client.ts
@@ -8,6 +8,7 @@ export const GET_ROUTE = {
   FEES: "info/fee",
   ROOT: "info/root",
   STATECHAIN: "info/statechain",
+  STATECOIN: "info/statecoin",
   STATECHAIN_OWNER: "info/owner",
   COINS_INFO: "info/coins",
   TRANSFER_BATCH: "info/transfer-batch",

--- a/src/wallet/index.js
+++ b/src/wallet/index.js
@@ -16,5 +16,5 @@ export { txBackupBuild, verifySmtProof, pubKeyToScriptPubKey, pubKeyTobtcAddr,
   fromSatoshi, encryptAES, decryptAES, encodeSCEAddress } from "./util"
 
 export { depositInit, depositConfirm } from "./mercury/deposit"
-export { getFeeInfo, getRoot, getStateChain, getSmtProof, getTransferBatchStatus,
+export { getFeeInfo, getRoot, getStateChain, getStateCoin, getSmtProof, getTransferBatchStatus,
   getRecoveryRequest } from "./mercury/info_api"

--- a/src/wallet/mercury/info_api.ts
+++ b/src/wallet/mercury/info_api.ts
@@ -136,10 +136,7 @@ export const getStateCoin = async (
   http_client: HttpClient |  MockHttpClient,
   statechain_id: string
 ) => {
-  console.log(`getStateCoin...`)
   let statecoin = await http_client.get(GET_ROUTE.STATECOIN, statechain_id);
-
-  console.log(`gotStateCoin: ${JSON.stringify(statecoin)}`)
 
   if (typeof statecoin.utxo == "string"){
     let outpoint = {
@@ -149,12 +146,7 @@ export const getStateCoin = async (
     statecoin.utxo=outpoint;
   }
   
-  console.log(`gotStateCoin 2: ${JSON.stringify(statecoin)}`)
-
   typeforce(types.StateCoinDataAPI, statecoin);
-
-
-  console.log(`gotStateCoin: typeforce done`)
   return statecoin
 }
 

--- a/src/wallet/mercury/info_api.ts
+++ b/src/wallet/mercury/info_api.ts
@@ -20,6 +20,13 @@ export interface StateChainDataAPI {
   locktime: number,
 }
 
+export interface StateCoinDataAPI {
+  utxo: OutPoint,
+  amount: number,
+  statecoin: any,
+  locktime: number,
+}
+
 export interface Root {
 id: number,
 value: number[],
@@ -112,7 +119,7 @@ export const getStateChain = async (
   statechain_id: string
 ) => {
   let statechain = await http_client.get(GET_ROUTE.STATECHAIN, statechain_id);
-  
+
   if (typeof statechain.utxo == "string"){
     let outpoint = {
       txid: statechain.utxo.substring(0,64),
@@ -123,6 +130,32 @@ export const getStateChain = async (
 
   typeforce(types.StateChainDataAPI, statechain);
   return statechain
+}
+
+export const getStateCoin = async (
+  http_client: HttpClient |  MockHttpClient,
+  statechain_id: string
+) => {
+  console.log(`getStateCoin...`)
+  let statecoin = await http_client.get(GET_ROUTE.STATECOIN, statechain_id);
+
+  console.log(`gotStateCoin: ${JSON.stringify(statecoin)}`)
+
+  if (typeof statecoin.utxo == "string"){
+    let outpoint = {
+      txid: statecoin.utxo.substring(0,64),
+      vout:parseInt(statecoin.utxo.substring(65))
+    }
+    statecoin.utxo=outpoint;
+  }
+  
+  console.log(`gotStateCoin 2: ${JSON.stringify(statecoin)}`)
+
+  typeforce(types.StateCoinDataAPI, statecoin);
+
+
+  console.log(`gotStateCoin: typeforce done`)
+  return statecoin
 }
 
 export const getOwner = async (

--- a/src/wallet/mercury/info_api.ts
+++ b/src/wallet/mercury/info_api.ts
@@ -13,6 +13,17 @@ export interface OutPoint {
   vout: number,
 }
 
+export interface StateChainSig {
+  purpose: string,
+  data: string,
+  sig: string
+}
+
+export interface State {
+  data: string,
+  next_state: StateChainSig | null
+}
+
 export interface StateChainDataAPI {
   utxo: OutPoint,
   amount: number,
@@ -23,42 +34,42 @@ export interface StateChainDataAPI {
 export interface StateCoinDataAPI {
   utxo: OutPoint,
   amount: number,
-  statecoin: any,
+  statecoin: State,
   locktime: number,
 }
 
 export interface Root {
-id: number,
-value: number[],
-commitment_info: any
+  id: number,
+  value: number[],
+  commitment_info: any
 }
 
 export interface FeeInfo {
-address: string,
-deposit: number,
-withdraw: number,
-interval: number,
-initlock: number,
-wallet_version: string,
-wallet_warning: string
+  address: string,
+  deposit: number,
+  withdraw: number,
+  interval: number,
+  initlock: number,
+  wallet_version: string,
+  wallet_warning: string
 }
 
 export interface RecoveryRequest {
-key: string,
-sig: string
+  key: string,
+  sig: string
 }
 
 export interface RecoveryDataMsg {
-shared_key_id: string,
-statechain_id: string,
-amount: number,
-tx_hex: string,
-proof_key: string,
-shared_key_data: string
+  shared_key_id: string,
+  statechain_id: string,
+  amount: number,
+  tx_hex: string,
+  proof_key: string,
+  shared_key_data: string
 }
 
 export const pingServer = async (
-  http_client: HttpClient |  MockHttpClient,
+  http_client: HttpClient | MockHttpClient,
 ) => {
   var startTime = performance.now()
   await http_client.get(GET_ROUTE.PING, {})
@@ -67,7 +78,7 @@ export const pingServer = async (
 }
 
 export const pingConductor = async (
-  http_client: HttpClient |  MockHttpClient,
+  http_client: HttpClient | MockHttpClient,
 ) => {
   var startTime = performance.now()
   await http_client.get(GET_ROUTE.SWAP_PING, {})
@@ -76,11 +87,11 @@ export const pingConductor = async (
 }
 
 export const pingElectrum = async (
-  electrum_client: ElectrumClient | ElectrsClient | EPSClient |  MockElectrumClient,
+  electrum_client: ElectrumClient | ElectrsClient | EPSClient | MockElectrumClient,
 ) => {
   var startTime = performance.now()
   let result = await electrum_client.ping()
-  if (result !== true){
+  if (result !== true) {
     throw Error("failed to ping electrum server")
   }
   var endTime = performance.now()
@@ -88,26 +99,26 @@ export const pingElectrum = async (
 }
 
 export const getFeeInfo = async (
-  http_client: HttpClient |  MockHttpClient,
+  http_client: HttpClient | MockHttpClient,
 ) => {
   let fee_info = await http_client.get(GET_ROUTE.FEES, {});
-  typeforce(types.FeeInfo, fee_info);  
+  typeforce(types.FeeInfo, fee_info);
 
-  if(fee_info && show_alerts) {
-    if(semver.lt(version, fee_info.wallet_version)) {
+  if (fee_info && show_alerts) {
+    if (semver.lt(version, fee_info.wallet_version)) {
       alert("Wallet version (" + version + ") incompatible with minimum server requirement (" + fee_info.wallet_version + "). Please upgrade to the latest version.")
     }
-    if(fee_info.wallet_message.length > 1) {
-      alert("Server alert: "+fee_info.wallet_message)
+    if (fee_info.wallet_message.length > 1) {
+      alert("Server alert: " + fee_info.wallet_message)
     }
     show_alerts = false;
-  }  
+  }
 
   return fee_info
 }
 
 export const getCoinsInfo = async (
-  http_client: HttpClient |  MockHttpClient,
+  http_client: HttpClient | MockHttpClient,
 ) => {
   let coins_info = await http_client.get(GET_ROUTE.COINS_INFO, {});
   typeforce(types.CoinsInfo, coins_info);
@@ -115,17 +126,17 @@ export const getCoinsInfo = async (
 }
 
 export const getStateChain = async (
-  http_client: HttpClient |  MockHttpClient,
+  http_client: HttpClient | MockHttpClient,
   statechain_id: string
 ) => {
   let statechain = await http_client.get(GET_ROUTE.STATECHAIN, statechain_id);
 
-  if (typeof statechain.utxo == "string"){
+  if (typeof statechain.utxo == "string") {
     let outpoint = {
-      txid: statechain.utxo.substring(0,64),
-      vout:parseInt(statechain.utxo.substring(65))
+      txid: statechain.utxo.substring(0, 64),
+      vout: parseInt(statechain.utxo.substring(65))
     }
-    statechain.utxo=outpoint;
+    statechain.utxo = outpoint;
   }
 
   typeforce(types.StateChainDataAPI, statechain);
@@ -133,48 +144,48 @@ export const getStateChain = async (
 }
 
 export const getStateCoin = async (
-  http_client: HttpClient |  MockHttpClient,
+  http_client: HttpClient | MockHttpClient,
   statechain_id: string
 ) => {
   let statecoin = await http_client.get(GET_ROUTE.STATECOIN, statechain_id);
 
-  if (typeof statecoin.utxo == "string"){
+  if (typeof statecoin.utxo == "string") {
     let outpoint = {
-      txid: statecoin.utxo.substring(0,64),
-      vout:parseInt(statecoin.utxo.substring(65))
+      txid: statecoin.utxo.substring(0, 64),
+      vout: parseInt(statecoin.utxo.substring(65))
     }
-    statecoin.utxo=outpoint;
+    statecoin.utxo = outpoint;
   }
-  
+
   typeforce(types.StateCoinDataAPI, statecoin);
   return statecoin
 }
 
 export const getOwner = async (
-  http_client: HttpClient |  MockHttpClient,
+  http_client: HttpClient | MockHttpClient,
   statechain_id: string
 ) => {
   let owner_id = await http_client.get(GET_ROUTE.STATECHAIN_OWNER, statechain_id);
-  
+
   return owner_id.shared_key_id
 }
 
 export const getRoot = async (
-  http_client: HttpClient |  MockHttpClient
+  http_client: HttpClient | MockHttpClient
 ) => {
   let root = await http_client.get(GET_ROUTE.ROOT, {});
   typeforce(typeforce.oneOf(types.Root, typeforce.Null), root);
   return root
 }
 
-export const delay = (ms:number) => {
+export const delay = (ms: number) => {
   return new Promise(resolve => {
     setTimeout(resolve, ms);
   })
 }
 
 export const getSmtProof = async (
-  http_client: HttpClient |  MockHttpClient,
+  http_client: HttpClient | MockHttpClient,
   root: Root | null,
   funding_txid: string
 ) => {
@@ -185,11 +196,11 @@ export const getSmtProof = async (
   };
 
   // try 5 times to get proof from server
-  let attempts =  0;
+  let attempts = 0;
   let proof = null;
-  while(attempts < 5){
+  while (attempts < 5) {
     proof = await http_client.post(POST_ROUTE.SMT_PROOF, smt_proof_msg_api);
-    if(proof !== null){
+    if (proof !== null) {
       typeforce(types.Array, proof);
       return proof;
     }
@@ -201,14 +212,14 @@ export const getSmtProof = async (
 }
 
 export const getTransferBatchStatus = async (
-  http_client: HttpClient |  MockHttpClient,
+  http_client: HttpClient | MockHttpClient,
   batch_id: string
 ) => {
   return await http_client.get(GET_ROUTE.TRANSFER_BATCH, batch_id);
 }
 
 export const getRecoveryRequest = async (
-  http_client: HttpClient |  MockHttpClient,
+  http_client: HttpClient | MockHttpClient,
   recovery_request: RecoveryRequest[]
 ) => {
   let recovery_data = await http_client.post(POST_ROUTE.RECOVER, recovery_request);

--- a/src/wallet/mercury/transfer.ts
+++ b/src/wallet/mercury/transfer.ts
@@ -5,7 +5,8 @@ import { ElectrumClient, MockElectrumClient, HttpClient, MockHttpClient, POST_RO
 import { ElectrsClient } from "../electrs"
 import { EPSClient } from "../eps"
 import { FEE } from "../util";
-import { FeeInfo, getFeeInfo, getRoot, getSmtProof, getStateChain, getOwner } from "./info_api";
+import { FeeInfo, getFeeInfo, getRoot, getSmtProof, getStateChain, 
+  getStateCoin, getOwner } from "./info_api";
 import { keyGen, PROTOCOL, sign } from "./ecdsa";
 import { encodeSecp256k1Point, StateChainSig, proofKeyToSCEAddress, pubKeyToScriptPubKey, encryptECIES, decryptECIES, getSigHash } from "../util";
 import { Wallet } from "../wallet";
@@ -72,9 +73,9 @@ export const transferSender = async (
   let fee_info: FeeInfo = await getFeeInfo(http_client);
 
   // Get statechain from SE and check ownership
-  let statechain_data = await getStateChain(http_client, statecoin.statechain_id);
-  if (statechain_data.amount === 0) throw Error("StateChain " + statecoin.statechain_id + " already withdrawn.");
-  let sc_statecoin = statechain_data.chain.pop();
+  let statecoin_data = await getStateCoin(http_client, statecoin.statechain_id);
+  if (statecoin_data.amount === 0) throw Error("StateChain " + statecoin.statechain_id + " already withdrawn.");
+  let sc_statecoin = statecoin_data.statecoin;
   if (sc_statecoin.data !== statecoin.proof_key) throw Error("StateChain not owned by this Wallet. Incorrect proof key: chain has " + sc_statecoin.data + ", expected " + statecoin.proof_key);
 
   // Sign statecoin to signal desire to Transfer
@@ -91,7 +92,7 @@ export const transferSender = async (
 
   // Edit backup tx with new owners proof-key address and sign
   new_tx_backup.outs[0].script = pubKeyToScriptPubKey(receiver_addr, network);
-  new_tx_backup.locktime = statechain_data.locktime - fee_info.interval;
+  new_tx_backup.locktime = statecoin_data.locktime - fee_info.interval;
 
   let pk = statecoin.getSharedPubKey();
   let signatureHash = getSigHash(new_tx_backup, 0, pk, statecoin.value, network);

--- a/src/wallet/mercury/withdraw.ts
+++ b/src/wallet/mercury/withdraw.ts
@@ -5,7 +5,7 @@ import { getFeeInfo, HttpClient, MockHttpClient, POST_ROUTE, StateCoin } from ".
 import { PrepareSignTxMsg } from "./ecdsa";
 import { getSigHash, StateChainSig, txWithdrawBuildBatch, txWithdrawBuild } from "../util";
 import { PROTOCOL, sign, sign_batch } from "./ecdsa";
-import { FeeInfo, getStateChain, StateChainDataAPI, getStateCoin, StateCoinDataAPI } from "./info_api";
+import { FeeInfo, getStateChain, StateChainDataAPI, State, getStateCoin, StateCoinDataAPI } from "./info_api";
 
 // withdraw() messages:
 // 0. request withdraw and provide withdraw tx data
@@ -51,7 +51,9 @@ export const withdraw = async (
       throw Error("StateChain " + statecoin.statechain_id + " already withdrawn.");
     }
 
-    let chain_data = statecoin_data.statecoin.data;
+    console.log(`withdraw - statecoin_data: ${JSON.stringify(statecoin_data)}`)
+    let sc_statecoin: State = statecoin_data.statecoin;
+    let chain_data = sc_statecoin.data;
     if (chain_data !== statecoin.proof_key) {
       throw Error("StateChain not owned by this Wallet. Incorrect proof key. Expected " + statecoin.proof_key + ", got " + chain_data);
     }

--- a/src/wallet/mercury/withdraw.ts
+++ b/src/wallet/mercury/withdraw.ts
@@ -5,7 +5,7 @@ import { getFeeInfo, HttpClient, MockHttpClient, POST_ROUTE, StateCoin } from ".
 import { PrepareSignTxMsg } from "./ecdsa";
 import { getSigHash, StateChainSig, txWithdrawBuildBatch, txWithdrawBuild } from "../util";
 import { PROTOCOL, sign, sign_batch } from "./ecdsa";
-import { FeeInfo, getStateChain, StateChainDataAPI } from "./info_api";
+import { FeeInfo, getStateChain, StateChainDataAPI, getStateCoin, StateCoinDataAPI } from "./info_api";
 
 // withdraw() messages:
 // 0. request withdraw and provide withdraw tx data
@@ -25,7 +25,7 @@ export const withdraw = async (
   fee_per_byte: number
 ): Promise<Transaction> => {
 
-  let sc_infos: StateChainDataAPI[] = [];
+  let sc_infos: StateCoinDataAPI[] = [];
   let pks: any[] = [];
   let statechain_sigs: StateChainSig[] = [];
   let shared_key_ids: string[] = [];
@@ -44,14 +44,14 @@ export const withdraw = async (
 
     let proof_key_der: BIP32Interface = proof_key_ders[index];
     // Get statechain from SE and check ownership
-    let statechain: StateChainDataAPI = await getStateChain(http_client, statecoin.statechain_id);
-    sc_infos.push(statechain);
+    let statecoin_data: StateCoinDataAPI = await getStateCoin(http_client, statecoin.statechain_id);
+    sc_infos.push(statecoin_data);
 
-    if (statechain.amount === 0) {
+    if (statecoin_data.amount === 0) {
       throw Error("StateChain " + statecoin.statechain_id + " already withdrawn.");
     }
 
-    let chain_data = statechain.chain.pop().data;
+    let chain_data = statecoin_data.statecoin.data;
     if (chain_data !== statecoin.proof_key) {
       throw Error("StateChain not owned by this Wallet. Incorrect proof key. Expected " + statecoin.proof_key + ", got " + chain_data);
     }

--- a/src/wallet/mercury/withdraw.ts
+++ b/src/wallet/mercury/withdraw.ts
@@ -5,7 +5,7 @@ import { getFeeInfo, HttpClient, MockHttpClient, POST_ROUTE, StateCoin } from ".
 import { PrepareSignTxMsg } from "./ecdsa";
 import { getSigHash, StateChainSig, txWithdrawBuildBatch, txWithdrawBuild } from "../util";
 import { PROTOCOL, sign, sign_batch } from "./ecdsa";
-import { FeeInfo, getStateChain, StateChainDataAPI, State, getStateCoin, StateCoinDataAPI } from "./info_api";
+import { FeeInfo, getStateChain, StateChainDataAPI } from "./info_api";
 
 // withdraw() messages:
 // 0. request withdraw and provide withdraw tx data
@@ -25,7 +25,7 @@ export const withdraw = async (
   fee_per_byte: number
 ): Promise<Transaction> => {
 
-  let sc_infos: StateCoinDataAPI[] = [];
+  let sc_infos: StateChainDataAPI[] = [];
   let pks: any[] = [];
   let statechain_sigs: StateChainSig[] = [];
   let shared_key_ids: string[] = [];
@@ -44,16 +44,14 @@ export const withdraw = async (
 
     let proof_key_der: BIP32Interface = proof_key_ders[index];
     // Get statechain from SE and check ownership
-    let statecoin_data: StateCoinDataAPI = await getStateCoin(http_client, statecoin.statechain_id);
-    sc_infos.push(statecoin_data);
+    let statechain: StateChainDataAPI = await getStateChain(http_client, statecoin.statechain_id);
+    sc_infos.push(statechain);
 
-    if (statecoin_data.amount === 0) {
+    if (statechain.amount === 0) {
       throw Error("StateChain " + statecoin.statechain_id + " already withdrawn.");
     }
 
-    console.log(`withdraw - statecoin_data: ${JSON.stringify(statecoin_data)}`)
-    let sc_statecoin: State = statecoin_data.statecoin;
-    let chain_data = sc_statecoin.data;
+    let chain_data = statechain.chain.pop().data;
     if (chain_data !== statecoin.proof_key) {
       throw Error("StateChain not owned by this Wallet. Incorrect proof key. Expected " + statecoin.proof_key + ", got " + chain_data);
     }

--- a/src/wallet/mocks/mock_http_client.ts
+++ b/src/wallet/mocks/mock_http_client.ts
@@ -97,12 +97,33 @@ export const STATECHAIN_INFOS = [{
 }
 ]
 
+export const STATECOIN_INFOS = [{
+  utxo: "f62c9b74e276843a5d0fe0d3d0f3d73c06e118b822772c024aac3d840fbad3ce:1",
+  amount: 1000,
+  statecoin: { data: "03ffac3c7d7db6308816e8589af9d6e9e724eb0ca81a44456fef02c79cba984477", next_state: null },
+  locktime: 1000
+},
+{
+  utxo: "f62c9b74e276843a5d0fe0d3d0f3d73c06e118b822772c024aac3d840fbad3de:1",
+  amount: 1000,
+  statecoin: { data: "03ffac3c7d7db6308816e8589af9d6e9e724eb0ca81a44456fef02c79cba984478", next_state: null },
+  locktime: 1000
+}
+]
+
 
 
 export const STATECHAIN_INFO =  {
   utxo: "794610eff71928df4d6814843945dbe51d8d11cdbcbeb11eb1c42e8199298494:0",
   amount: 500000,
   chain: [{ data: "03ffac3c7d7db6308816e8589af9d6e9e724eb0ca81a44456fef02c79cba984477", next_state: null }],
+  locktime: 1000
+}
+
+export const STATECOIN_INFO =  {
+  utxo: "794610eff71928df4d6814843945dbe51d8d11cdbcbeb11eb1c42e8199298494:0",
+  amount: 500000,
+  statecoin: { data: "03ffac3c7d7db6308816e8589af9d6e9e724eb0ca81a44456fef02c79cba984477", next_state: null },
   locktime: 1000
 }
 

--- a/src/wallet/swap/swap.ts
+++ b/src/wallet/swap/swap.ts
@@ -4,7 +4,7 @@ import { ElectrsClient } from '../electrs'
 import { EPSClient } from '../eps'
 import { transferSender, transferReceiver, TransferFinalizeData, transferReceiverFinalize, SCEAddress} from "../mercury/transfer"
 import { pollUtxo, pollSwap, getSwapInfo, swapRegisterUtxo, swapDeregisterUtxo } from "./info_api";
-import { getStateChain } from "../mercury/info_api";
+import { getStateChain, getStateCoin } from "../mercury/info_api";
 import { StateChainSig } from "../util";
 import { BIP32Interface, Network, script } from 'bitcoinjs-lib';
 import { v4 as uuidv4 } from 'uuid';
@@ -789,8 +789,7 @@ export const first_message = async (
 ): Promise<BSTRequestorData> => {
 
   let swap_token = swap_info.swap_token;
-  let statechain_data = await getStateChain(http_client, statechain_id);
-  typeforce(types.StateChainDataAPI, statechain_data);
+  let statecoin_data = await getStateCoin(http_client, statechain_id);
 
   let swap_token_class = new SwapToken(swap_token.id, swap_token.amount, swap_token.time_out, swap_token.statechain_ids);
   let swap_token_sig = swap_token_class.sign(proof_key_der);

--- a/src/wallet/test/mercury.test.js
+++ b/src/wallet/test/mercury.test.js
@@ -124,7 +124,7 @@ describe('StateChain Entity', function() {
     let fee_per_byte = 1;
     test('Expect complete', async function() {
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
         .mockReturnValueOnce(cloneDeep(MOCK_SERVER.FEE_INFO));
       http_mock.post = jest.fn().mockReset()
         .mockReturnValueOnce(true)   //POST.WITHDRAW_INIT
@@ -152,7 +152,7 @@ describe('StateChain Entity', function() {
       expect(tx_withdraw.locktime).toBe(0);
     });
     test('Already withdrawn.', async function() {
-      let statechain_info = cloneDeep(MOCK_SERVER.STATECOIN_INFO);
+      let statechain_info = cloneDeep(MOCK_SERVER.STATECHAIN_INFO);
 
       statechain_info.amount = 0;
       http_mock.get = jest.fn().mockReset()
@@ -165,7 +165,7 @@ describe('StateChain Entity', function() {
 
     test('StateChain not owned by this wallet.', async function() {
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
 
       let statecoin = makeTesterStatecoin();
       statecoin.proof_key = "aaa";
@@ -179,7 +179,7 @@ describe('StateChain Entity', function() {
       fee_info.withdraw = 10000;
 
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
         .mockReturnValueOnce(fee_info)
       http_mock.post = jest.fn().mockReset()
         .mockReturnValueOnce(true)   //POST.WITHDRAW_INIT
@@ -197,8 +197,8 @@ describe('StateChain Entity', function() {
     let fee_per_byte = 1
     test('Expect complete', async function() {
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFOS[0]))
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFOS[1]))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFOS[0]))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFOS[1]))
         .mockReturnValueOnce(MOCK_SERVER.FEE_INFO)
         .mockReturnValueOnce(MOCK_SERVER.FEE_INFO);
       http_mock.post = jest.fn().mockReset()
@@ -230,7 +230,7 @@ describe('StateChain Entity', function() {
       expect(tx_withdraw.locktime).toBe(0);
     });
     test('Already withdrawn.', async function() {
-      let statechain_info = cloneDeep(MOCK_SERVER.STATECOIN_INFO);
+      let statechain_info = cloneDeep(MOCK_SERVER.STATECHAIN_INFO);
       statechain_info.amount = 0;
       http_mock.get = jest.fn().mockReset()
         .mockReturnValueOnce(statechain_info)
@@ -241,7 +241,7 @@ describe('StateChain Entity', function() {
     });
     test('StateChain not owned by this wallet.', async function() {
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
 
       let statecoin = cloneDeep(makeTesterStatecoins()[0]);
       statecoin.proof_key = "aaa";
@@ -254,8 +254,8 @@ describe('StateChain Entity', function() {
       fee_info.withdraw = 10000;
 
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFOS[0]))
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFOS[1]))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFOS[0]))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFOS[1]))
         .mockReturnValueOnce(fee_info)
       http_mock.post = jest.fn().mockReset()
         .mockReturnValueOnce(true)   //POST.WITHDRAW_INIT

--- a/src/wallet/test/mercury.test.js
+++ b/src/wallet/test/mercury.test.js
@@ -124,7 +124,7 @@ describe('StateChain Entity', function() {
     let fee_per_byte = 1;
     test('Expect complete', async function() {
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFO))
         .mockReturnValueOnce(cloneDeep(MOCK_SERVER.FEE_INFO));
       http_mock.post = jest.fn().mockReset()
         .mockReturnValueOnce(true)   //POST.WITHDRAW_INIT
@@ -152,7 +152,7 @@ describe('StateChain Entity', function() {
       expect(tx_withdraw.locktime).toBe(0);
     });
     test('Already withdrawn.', async function() {
-      let statechain_info = cloneDeep(MOCK_SERVER.STATECHAIN_INFO);
+      let statechain_info = cloneDeep(MOCK_SERVER.STATECOIN_INFO);
 
       statechain_info.amount = 0;
       http_mock.get = jest.fn().mockReset()
@@ -165,7 +165,7 @@ describe('StateChain Entity', function() {
 
     test('StateChain not owned by this wallet.', async function() {
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFO))
 
       let statecoin = makeTesterStatecoin();
       statecoin.proof_key = "aaa";
@@ -179,7 +179,7 @@ describe('StateChain Entity', function() {
       fee_info.withdraw = 10000;
 
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFO))
         .mockReturnValueOnce(fee_info)
       http_mock.post = jest.fn().mockReset()
         .mockReturnValueOnce(true)   //POST.WITHDRAW_INIT
@@ -197,8 +197,8 @@ describe('StateChain Entity', function() {
     let fee_per_byte = 1
     test('Expect complete', async function() {
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFOS[0]))
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFOS[1]))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFOS[0]))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFOS[1]))
         .mockReturnValueOnce(MOCK_SERVER.FEE_INFO)
         .mockReturnValueOnce(MOCK_SERVER.FEE_INFO);
       http_mock.post = jest.fn().mockReset()
@@ -230,7 +230,7 @@ describe('StateChain Entity', function() {
       expect(tx_withdraw.locktime).toBe(0);
     });
     test('Already withdrawn.', async function() {
-      let statechain_info = cloneDeep(MOCK_SERVER.STATECHAIN_INFO);
+      let statechain_info = cloneDeep(MOCK_SERVER.STATECOIN_INFO);
       statechain_info.amount = 0;
       http_mock.get = jest.fn().mockReset()
         .mockReturnValueOnce(statechain_info)
@@ -241,7 +241,7 @@ describe('StateChain Entity', function() {
     });
     test('StateChain not owned by this wallet.', async function() {
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFO))
 
       let statecoin = cloneDeep(makeTesterStatecoins()[0]);
       statecoin.proof_key = "aaa";
@@ -254,8 +254,8 @@ describe('StateChain Entity', function() {
       fee_info.withdraw = 10000;
 
       http_mock.get = jest.fn().mockReset()
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFOS[0]))
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFOS[1]))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFOS[0]))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFOS[1]))
         .mockReturnValueOnce(fee_info)
       http_mock.post = jest.fn().mockReset()
         .mockReturnValueOnce(true)   //POST.WITHDRAW_INIT
@@ -273,7 +273,7 @@ describe('StateChain Entity', function() {
     test('Expect complete', async function() {
       http_mock.get = jest.fn().mockReset()
         .mockReturnValueOnce(MOCK_SERVER.FEE_INFO)
-        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECHAIN_INFO))
+        .mockReturnValueOnce(cloneDeep(MOCK_SERVER.STATECOIN_INFO))
       http_mock.post = jest.fn().mockReset()
         .mockReturnValueOnce(MOCK_SERVER.TRANSFER_SENDER)
       //Sign

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -28,6 +28,31 @@ export const StateChainDataAPI = typeforce.compile({
     locktime: Number,
 })
 
+/// State change signature object
+/// Data necessary to create ownership transfer signatures
+export const StateChainSig = typeforce.compile({
+  /// Purpose: "TRANSFER", "TRANSFER-BATCH" or "WITHDRAW"
+  purpose: String, // "TRANSFER", "TRANSFER-BATCH" or "WITHDRAW"
+  /// The new owner proof public key (if transfer) or address (if withdrawal)
+  data: String,    // proof key, state chain id or address
+  /// Current owner signature (DER encoded).
+  sig: String,
+})
+
+// StateChain Entity API
+//export const State = typeforce.compile({
+//  data: String,
+//  next_state: Any
+//})
+
+// StateChain Entity API
+export const StateCoinDataAPI = typeforce.compile({
+  utxo: OutPoint,
+  amount: Number,
+  statecoin: Object,
+  locktime: Number,
+})
+
 export const Root = typeforce.compile({
   id: UInt32,
   value: Array,
@@ -307,16 +332,7 @@ export const SwapInfo = typeforce.compile({
     bst_sender_data: BSTSenderData,
 })
 
-/// State change signature object
-/// Data necessary to create ownership transfer signatures
-export const StateChainSig = typeforce.compile({
-    /// Purpose: "TRANSFER", "TRANSFER-BATCH" or "WITHDRAW"
-    purpose: String, // "TRANSFER", "TRANSFER-BATCH" or "WITHDRAW"
-    /// The new owner proof public key (if transfer) or address (if withdrawal)
-    data: String,    // proof key, state chain id or address
-    /// Current owner signature (DER encoded).
-    sig: String,
-})
+
 
 
 /// Owner -> Conductor

--- a/src/wallet/util.ts
+++ b/src/wallet/util.ts
@@ -1,7 +1,7 @@
 // wallet utilities
 
 import { BIP32Interface, Network, TransactionBuilder, crypto as crypto_btc, script, Transaction } from 'bitcoinjs-lib';
-import { Root, StateCoinDataAPI, FeeInfo, OutPoint } from './mercury/info_api';
+import { Root, StateChainDataAPI, FeeInfo, OutPoint } from './mercury/info_api';
 import { Secp256k1Point } from './mercury/transfer';
 import { TransferMsg3, PrepareSignTxMsg } from './mercury/transfer';
 
@@ -165,7 +165,7 @@ export const txWithdrawBuild = (network: Network,    funding_txid: string, fundi
 // Withdraw tx builder spending funding tx to:
 //     - amount-fee to receive address, and
 //     - amount 'fee' to State Entity fee address
-export const txWithdrawBuildBatch = (network: Network, sc_infos: Array<StateCoinDataAPI>, rec_address: string, fee_info: FeeInfo, fee_per_byte: number): TransactionBuilder => {
+export const txWithdrawBuildBatch = (network: Network, sc_infos: Array<StateChainDataAPI>, rec_address: string, fee_info: FeeInfo, fee_per_byte: number): TransactionBuilder => {
   // let txin = []; - not being used
   let value = 0;
   let txb: TransactionBuilder = new TransactionBuilder(network);

--- a/src/wallet/util.ts
+++ b/src/wallet/util.ts
@@ -1,7 +1,7 @@
 // wallet utilities
 
 import { BIP32Interface, Network, TransactionBuilder, crypto as crypto_btc, script, Transaction } from 'bitcoinjs-lib';
-import { Root, StateChainDataAPI, FeeInfo, OutPoint } from './mercury/info_api';
+import { Root, StateCoinDataAPI, FeeInfo, OutPoint } from './mercury/info_api';
 import { Secp256k1Point } from './mercury/transfer';
 import { TransferMsg3, PrepareSignTxMsg } from './mercury/transfer';
 
@@ -165,7 +165,7 @@ export const txWithdrawBuild = (network: Network,    funding_txid: string, fundi
 // Withdraw tx builder spending funding tx to:
 //     - amount-fee to receive address, and
 //     - amount 'fee' to State Entity fee address
-export const txWithdrawBuildBatch = (network: Network, sc_infos: Array<StateChainDataAPI>, rec_address: string, fee_info: FeeInfo, fee_per_byte: number): TransactionBuilder => {
+export const txWithdrawBuildBatch = (network: Network, sc_infos: Array<StateCoinDataAPI>, rec_address: string, fee_info: FeeInfo, fee_per_byte: number): TransactionBuilder => {
   // let txin = []; - not being used
   let value = 0;
   let txb: TransactionBuilder = new TransactionBuilder(network);


### PR DESCRIPTION
- Use the getStateCoin API instead of the getStateChain API when only the statechain tip is needed
- Improve the error handling of the tor adapter tor circuit info APIs leading to improved reliability