### PR TITLE
Expiry date not set when connection drops

### DIFF
--- a/src/components/coins/coins.js
+++ b/src/components/coins/coins.js
@@ -226,17 +226,11 @@ const Coins = (props) => {
     } 
 
     const validExpiryTime = (expiry_data) => {
-      if(callGetBlockHeight() === 0){
+      let block_height = callGetBlockHeight()
+
+      if(block_height === 0 || expiry_data.block === 0 || !block_height){
         // set its actual block to 0 so next time we can return  '--' until an actual block is received
         expiry_data.blocks = 0;
-        return false;
-      }
-
-      if(expiry_data === undefined){
-        return false;
-      }
-
-      if(expiry_data.blocks === 0){
         return false;
       }
 


### PR DESCRIPTION
Issue #1091 Fixed:

Expiry date is calculated by : blocks until expiry - current block height

If connection drops block height is set to null:

blocks until expiry - null = blocks until expiry, which is a lot higher than it's meant to be

This is now shown as an error state which displays expiry date as "--"