### PR TITLE
Feature/hide balance

### DIFF
--- a/src/components/coins/Coin/Coin.js
+++ b/src/components/coins/Coin/Coin.js
@@ -13,6 +13,7 @@ import Moment from "react-moment";
 import SwapStatus from "../SwapStatus/SwapStatus";
 import { callGetActivityLog, callGetActivityLogItems, setError } from "../../../features/WalletDataSlice";
 import { CoinStatus, CopiedButton } from "../..";
+import { HIDDEN } from '../../../wallet/statecoin';
 
 const TESTING_MODE = require("../../../settings.json").testing_mode;
 const SWAP_AMOUNTS = require("../../../settings.json").swap_amounts;
@@ -169,7 +170,7 @@ const Coin = (props) => {
           <div className="CoinAmount-block">
             <img src={props.coin_data.privacy_data.icon1} alt="icon" />
             <span className="sub">
-              <b className={props.coin_data.value < MINIMUM_DEPOSIT_SATOSHI ? "CoinAmountError" : "CoinAmount"}>  {fromSatoshi(props.coin_data.value)} BTC</b>
+              <b className={props.coin_data.value < MINIMUM_DEPOSIT_SATOSHI ? "CoinAmountError" : "CoinAmount"}>  {props.balance_info.hidden ? HIDDEN : fromSatoshi(props.coin_data.value)} BTC</b>
               {props.filterBy === STATECOIN_STATUS.IN_TRANSFER ? (
                 <div className="scoreAmount">
                   {updateTransferDate(props.coin_data)}

--- a/src/components/coins/CoinsList.js
+++ b/src/components/coins/CoinsList.js
@@ -595,7 +595,7 @@ const CoinsList = (props) => {
               <div className="block">
                 <span>Statecoin Value</span>
                 <span>
-                  <b>{balance_info.hidden ? HIDDEN : fromSatoshi(showCoinDetails.coin.value)} BTC</b>
+                  <b>{fromSatoshi(showCoinDetails.coin.value)} BTC</b>
                 </span>
               </div>
             </div>

--- a/src/components/coins/CoinsList.js
+++ b/src/components/coins/CoinsList.js
@@ -272,7 +272,7 @@ const CoinsList = (props) => {
       return () => { isMounted = false }
     }
   }
-    , [props.refresh, filterBy, showCoinDetails, dispatch, coinsAdded, coinsRemoved]);
+    , [props.refresh, filterBy, showCoinDetails, dispatch, coinsAdded, coinsRemoved, balance_info]);
 
   // Re-fetch every 5 seconds and update state to refresh render
   // IF any coins are marked UNCONFIRMED
@@ -282,7 +282,7 @@ const CoinsList = (props) => {
 
     return () => clearInterval(interval);
 
-  }, [coins.unConfirmedCoins, torInfo.online]);
+  }, [coins.unConfirmedCoins, torInfo.online, balance_info]);
 
 
   //Initialised Coin description for coin modal
@@ -300,7 +300,7 @@ const CoinsList = (props) => {
       setDscrpnConfirm(false)
     }
     //function called every time coin info modal shows up
-  }, [showCoinDetails.coin])
+  }, [showCoinDetails.coin, balance_info])
 
   // Re-fetch swaps group data every and update swaps component
   // Initiate auto swap
@@ -332,7 +332,7 @@ const CoinsList = (props) => {
       const total = confirmedCoins.reduce((sum, currentItem) => sum + currentItem.value, 0);
       dispatch(updateBalanceInfo({...balance_info, total_balance: total, num_coins: confirmedCoins.length }))
     }
-  }, [callGetUnspentStatecoins()])
+  }, [callGetUnspentStatecoins(), balance_info])
 
   // Enters/Re-enters coins in auto-swap
   const autoSwapLoop = () => {
@@ -576,7 +576,9 @@ const CoinsList = (props) => {
             getAddress={getAddress}
             displayExpiryTime={displayExpiryTime}
             handleAutoSwap={props.handleAutoSwap}
-            render={props.render ? (props.render) : null} />
+            render={props.render ? (props.render) : null}
+            balance_info={balance_info}
+          />
         )
       })}
 

--- a/src/components/coins/CoinsList.js
+++ b/src/components/coins/CoinsList.js
@@ -39,7 +39,7 @@ import {
 } from '../../features/WalletDataSlice';
 import SortBy from './SortBy/SortBy';
 import FilterBy from './FilterBy/FilterBy';
-import { STATECOIN_STATUS } from '../../wallet/statecoin';
+import { STATECOIN_STATUS, HIDDEN } from '../../wallet/statecoin';
 import { CoinStatus } from '..';
 import EmptyCoinDisplay from './EmptyCoinDisplay/EmptyCoinDisplay';
 import CopiedButton from "../CopiedButton";
@@ -100,7 +100,7 @@ const CoinsList = (props) => {
   const { selectedCoins, isMainPage, swap } = props;
   const dispatch = useDispatch();
   const { filterBy, swapPendingCoins, coinsAdded,
-    coinsRemoved, torInfo, inSwapValues } = useSelector(state => state.walletData);
+    coinsRemoved, torInfo, inSwapValues, balance_info } = useSelector(state => state.walletData);
   const [sortCoin, setSortCoin] = useState(INITIAL_SORT_BY);
   const [coins, setCoins] = useState(INITIAL_COINS);
   const [initCoins, setInitCoins] = useState({});
@@ -593,7 +593,7 @@ const CoinsList = (props) => {
               <div className="block">
                 <span>Statecoin Value</span>
                 <span>
-                  <b>{fromSatoshi(showCoinDetails.coin.value)} BTC</b>
+                  <b>{balance_info.hidden ? HIDDEN : fromSatoshi(showCoinDetails.coin.value)} BTC</b>
                 </span>
               </div>
             </div>

--- a/src/components/coins/CoinsList.js
+++ b/src/components/coins/CoinsList.js
@@ -259,7 +259,7 @@ const CoinsList = (props) => {
       if (filterBy !== 'default') {
         const coinsByStatus = filterCoinsByStatus([...coins_data, ...unconfirmed_coins_data], filterBy);
         const total = coinsByStatus.reduce((sum, currentItem) => sum + currentItem.value, 0);
-        dispatch(updateBalanceInfo({ total_balance: total, num_coins: coinsByStatus.length }));
+        dispatch(updateBalanceInfo({...balance_info, total_balance: total, num_coins: coinsByStatus.length }));
       } else {
         const coinsNotWithdraw = coins_data.filter(coin => (
           coin.status !== STATECOIN_STATUS.WITHDRAWN &&
@@ -267,7 +267,7 @@ const CoinsList = (props) => {
           coin.status !== STATECOIN_STATUS.IN_TRANSFER &&
           coin.status !== STATECOIN_STATUS.EXPIRED));
         const total = coinsNotWithdraw.reduce((sum, currentItem) => sum + currentItem.value, 0);
-        dispatch(updateBalanceInfo({ total_balance: total, num_coins: coinsNotWithdraw.length }));
+        dispatch(updateBalanceInfo({...balance_info,  total_balance: total, num_coins: coinsNotWithdraw.length }));
       }
       return () => { isMounted = false }
     }
@@ -330,7 +330,7 @@ const CoinsList = (props) => {
       setTotalCoins(confirmedCoins.length);
       // update balance and amount
       const total = confirmedCoins.reduce((sum, currentItem) => sum + currentItem.value, 0);
-      dispatch(updateBalanceInfo({ total_balance: total, num_coins: confirmedCoins.length }))
+      dispatch(updateBalanceInfo({...balance_info, total_balance: total, num_coins: confirmedCoins.length }))
     }
   }, [callGetUnspentStatecoins()])
 

--- a/src/components/panelControl/panelControl.js
+++ b/src/components/panelControl/panelControl.js
@@ -6,13 +6,15 @@ import swapIcon from '../../images/swap-icon.png';
 import arrowUp from '../../images/arrow-up.png';
 import arrowDown from '../../images/arrow-down.png';
 
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import React from 'react';
 import { Link } from "react-router-dom";
 
 import StdButton from '../buttons/standardButton';
 import { fromSatoshi } from '../../wallet/util'
-import { STATECOIN_STATUS } from '../../wallet/statecoin'
+import { STATECOIN_STATUS, HIDDEN } from '../../wallet/statecoin'
+import { updateBalanceInfo } from '../../features/WalletDataSlice';
+import { CheckBox } from "../../components";
 
 import './panelControl.css';
 import '../index.css';
@@ -41,12 +43,14 @@ export const FILTER_BY_OPTION = [
 ]
 
 const PanelControl = () => {
+  const dispatch = useDispatch();
   const balance_info = useSelector((state) => state.walletData.balance_info);
-  const filterBy  = useSelector((state) => state.walletData.filterBy);
-
+  const filterBy = useSelector((state) => state.walletData.filterBy);
+  const onHideBalanceChange = ({ checked }) => { dispatch(updateBalanceInfo({ ...balance_info, hidden: checked })) };
+  
   const filterByMsg = () => {
     let return_str = "Statecoin";
-    if (balance_info.num_coins !== 1) {
+    if (balance_info.hidden === true || balance_info.num_coins !== 1) {
       return_str = return_str+"s"
     }
     switch (filterBy) {
@@ -67,11 +71,21 @@ const PanelControl = () => {
     <div className="Body panelControl">
       <h2 className="WalletAmount">
           <img src={walletIcon} alt="walletIcon"/>
-          {fromSatoshi(balance_info.total_balance)} BTC
+          {balance_info.hidden ? HIDDEN : fromSatoshi(balance_info.total_balance)} BTC
       </h2>
         <div className="no-wallet">
-            <span>{balance_info.num_coins} {filterByMsg()}</span>
+            <span>{balance_info.hidden ? HIDDEN : balance_info.num_coins} {filterByMsg()}</span>
+      </div>
+      <div className="ButtonsPanel">
+        <div className="ActionGroupLeft">
+          <CheckBox
+            //label="Hide balance"
+            description={balance_info.hidden ? "Show balance" : "Hide balance"}
+            checked={!!balance_info.hide}
+            onChange={onHideBalanceChange}
+          />
         </div>
+      </div>
       <div className="ButtonsPanel">
         <div className="ActionGroupLeft">
 

--- a/src/components/panelControl/panelControl.js
+++ b/src/components/panelControl/panelControl.js
@@ -47,8 +47,8 @@ const PanelControl = () => {
   const balance_info = useSelector((state) => state.walletData.balance_info);
   const filterBy = useSelector((state) => state.walletData.filterBy);
   const onHideBalanceChange = ({ checked }) => {
-    console.log("clicked hide balance...")
-    dispatch(updateBalanceInfo({ hidden: checked }))
+    console.log(`clicked hide balance - setting to ${checked}...`)
+    dispatch(updateBalanceInfo({ ...balance_info, hidden: checked }))
   };
   
   const filterByMsg = () => {
@@ -83,6 +83,7 @@ const PanelControl = () => {
       <div className="ButtonsPanel">
         <div className="ActionGroupLeft">
 
+          
           <CheckBox
             label="Show/hide balance"
             description={balance_info.hidden ? "Show balance" : "Hide balance"}

--- a/src/components/panelControl/panelControl.js
+++ b/src/components/panelControl/panelControl.js
@@ -78,13 +78,13 @@ const PanelControl = () => {
       <div className="no-wallet">
         <span>{balance_info.hidden ? HIDDEN : balance_info.num_coins} {filterByMsg()}</span>
       </div>
-      
+      <div className="ActionGroupLeft">
       <CheckBox
         label={balance_info.hidden ? "Show balance" : "Hide balance"}
         checked={!!balance_info.hidden}
         onChange={onHideBalanceChange}
       />
-
+      </div>
       <div className="ButtonsPanel">
         <div className="ActionGroupLeft">
 

--- a/src/components/panelControl/panelControl.js
+++ b/src/components/panelControl/panelControl.js
@@ -46,7 +46,10 @@ const PanelControl = () => {
   const dispatch = useDispatch();
   const balance_info = useSelector((state) => state.walletData.balance_info);
   const filterBy = useSelector((state) => state.walletData.filterBy);
-  const onHideBalanceChange = ({ checked }) => { dispatch(updateBalanceInfo({ ...balance_info, hidden: checked })) };
+  const onHideBalanceChange = ({ checked }) => {
+    console.log("clicked hide balance...")
+    dispatch(updateBalanceInfo({ hidden: checked }))
+  };
   
   const filterByMsg = () => {
     let return_str = "Statecoin";
@@ -73,21 +76,19 @@ const PanelControl = () => {
           <img src={walletIcon} alt="walletIcon"/>
           {balance_info.hidden ? HIDDEN : fromSatoshi(balance_info.total_balance)} BTC
       </h2>
-        <div className="no-wallet">
-            <span>{balance_info.hidden ? HIDDEN : balance_info.num_coins} {filterByMsg()}</span>
+      <div className="no-wallet">
+        <span>{balance_info.hidden ? HIDDEN : balance_info.num_coins} {filterByMsg()}</span>
       </div>
+      
       <div className="ButtonsPanel">
         <div className="ActionGroupLeft">
+
           <CheckBox
-            //label="Hide balance"
+            label="Show/hide balance"
             description={balance_info.hidden ? "Show balance" : "Hide balance"}
-            checked={!!balance_info.hide}
+            checked={!!balance_info.hidden}
             onChange={onHideBalanceChange}
           />
-        </div>
-      </div>
-      <div className="ButtonsPanel">
-        <div className="ActionGroupLeft">
 
           <Link to="/deposit">
               <StdButton

--- a/src/components/panelControl/panelControl.js
+++ b/src/components/panelControl/panelControl.js
@@ -47,7 +47,6 @@ const PanelControl = () => {
   const balance_info = useSelector((state) => state.walletData.balance_info);
   const filterBy = useSelector((state) => state.walletData.filterBy);
   const onHideBalanceChange = ({ checked }) => {
-    console.log(`clicked hide balance - setting to ${checked}...`)
     dispatch(updateBalanceInfo({ ...balance_info, hidden: checked }))
   };
   
@@ -80,16 +79,17 @@ const PanelControl = () => {
         <span>{balance_info.hidden ? HIDDEN : balance_info.num_coins} {filterByMsg()}</span>
       </div>
       
+      <CheckBox
+        label={balance_info.hidden ? "Show balance" : "Hide balance"}
+        checked={!!balance_info.hidden}
+        onChange={onHideBalanceChange}
+      />
+
       <div className="ButtonsPanel">
         <div className="ActionGroupLeft">
 
           
-          <CheckBox
-            label={balance_info.hidden ? "Show balance" : "Hide balance"}
-            //description={balance_info.hidden ? "Show balance" : "Hide balance"}
-            checked={!!balance_info.hidden}
-            onChange={onHideBalanceChange}
-          />
+         
 
           <Link to="/deposit">
               <StdButton

--- a/src/components/panelControl/panelControl.js
+++ b/src/components/panelControl/panelControl.js
@@ -85,8 +85,8 @@ const PanelControl = () => {
 
           
           <CheckBox
-            label="Show/hide balance"
-            description={balance_info.hidden ? "Show balance" : "Hide balance"}
+            label={balance_info.hidden ? "Show balance" : "Hide balance"}
+            //description={balance_info.hidden ? "Show balance" : "Hide balance"}
             checked={!!balance_info.hidden}
             onChange={onHideBalanceChange}
           />

--- a/src/features/WalletDataSlice.js
+++ b/src/features/WalletDataSlice.js
@@ -13,6 +13,7 @@ import * as bitcoin from 'bitcoinjs-lib';
 import {mutex} from '../wallet/electrum';
 import { SWAP_STATUS } from '../wallet/swap/swap_utils'
 
+const isEqual = require('lodash').isEqual
 
 // eslint-disable-next-line
 const CLOSED = require('websocket').w3cwebsocket.CLOSED;
@@ -56,7 +57,7 @@ const initialState = {
   notification_dialogue: [],
   error_dialogue: { seen: true, msg: "" },
   warning_dialogue: {key: "", msg: "", seen: false},
-  balance_info: { total_balance: null, num_coins: null, hide_balance: false },
+  balance_info: {total_balance: null, num_coins: null, hidden: false},
   fee_info: {deposit: "NA", withdraw: "NA"},
   ping_swap: null,
   ping_server: null,
@@ -624,10 +625,14 @@ const WalletSlice = createSlice({
     },
     // Update total_balance
     updateBalanceInfo(state, action) {
-      let payload = action.payload 
-      return {
-        ...state,
-        balance_info: { ...state.balance_info, payload }
+      let payload = action.payload
+      let new_balance_info = {...state.balance_info, ...payload}
+      if(!isEqual(new_balance_info, state.balance_info)){
+        console.log(`Update balance info to: ${JSON.stringify(new_balance_info)}`)
+        return {
+          ...state,
+          balance_info: new_balance_info
+        }
       }
     },
     // Update fee_info

--- a/src/features/WalletDataSlice.js
+++ b/src/features/WalletDataSlice.js
@@ -624,11 +624,10 @@ const WalletSlice = createSlice({
     },
     // Update total_balance
     updateBalanceInfo(state, action) {
-      if (state.balance_info.total_balance !== action.payload.total_balance) {
-        return {
-          ...state,
-          balance_info: action.payload
-        }
+      let payload = action.payload 
+      return {
+        ...state,
+        balance_info: { ...state.balance_info, payload }
       }
     },
     // Update fee_info

--- a/src/features/WalletDataSlice.js
+++ b/src/features/WalletDataSlice.js
@@ -56,7 +56,7 @@ const initialState = {
   notification_dialogue: [],
   error_dialogue: { seen: true, msg: "" },
   warning_dialogue: {key: "", msg: "", seen: false},
-  balance_info: {total_balance: null, num_coins: null},
+  balance_info: { total_balance: null, num_coins: null, hide_balance: false },
   fee_info: {deposit: "NA", withdraw: "NA"},
   ping_swap: null,
   ping_server: null,

--- a/src/features/WalletDataSlice.js
+++ b/src/features/WalletDataSlice.js
@@ -628,7 +628,6 @@ const WalletSlice = createSlice({
       let payload = action.payload
       let new_balance_info = {...state.balance_info, ...payload}
       if(!isEqual(new_balance_info, state.balance_info)){
-        console.log(`Update balance info to: ${JSON.stringify(new_balance_info)}`)
         return {
           ...state,
           balance_info: new_balance_info

--- a/src/wallet/mercury/ecdsa.ts
+++ b/src/wallet/mercury/ecdsa.ts
@@ -142,7 +142,6 @@ export const sign = async (
 
     let resp: any[][] = await http_client.post(POST_ROUTE.SIGN_SECOND, sign_msg2);
      
-    console.log(`sign response: ${resp}`)
   return resp;
 }
 

--- a/src/wallet/statecoin.ts
+++ b/src/wallet/statecoin.ts
@@ -20,6 +20,8 @@ try {
   log = require('electron-log');
 }
 
+export const HIDDEN = "*****"
+
 export class StateCoinList {
   coins: StateCoin[]
 

--- a/src/wallet/test/swap.phase0.test.js
+++ b/src/wallet/test/swap.phase0.test.js
@@ -217,16 +217,18 @@ describe('swapPhase0 test 7 - waiting for swap to begin...', () => {
   })
 
   
-  it('swap Phase 0 should remain in phase 0 and not increment the n_retries counter', async () => {
+  it('swap Phase 0 should remain in phase 0 and not increment the n_retries counter past 1', async () => {
     let swap = new Swap(wallet, statecoin, null, null) 
     expect(swap.n_retries).toEqual(0)
     const input = () => {
       return swapPhase0(swap);
     }
-    let result = await input()
-    expect(result.is_ok()).toEqual(false)
-    expect(result.includes("Waiting for swap to begin..."))
-    expect(swap.n_retries).toEqual(0)
+    for (let i = 0; i < 3; i++) {
+      let result = await input()
+      expect(result.is_ok()).toEqual(false)
+      expect(result.includes("Waiting for swap to begin..."))
+      expect(swap.n_retries).toEqual(1)
+    }
   })
 })
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1284,8 +1284,8 @@ export class Wallet {
       let statecoin = this.statecoins.coins[i]
       try {
         await this.deRegisterSwapCoin(statecoin)
-      } catch (e) {
-        if (!e.message.includes("Coin is not in a swap pool")) {
+      } catch (e: any) {
+        if (!(e?.message && e.message.includes("Coin is not in a swap pool"))) {
           throw e
         }
       }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -184,7 +184,6 @@ export class Wallet {
     let electr_ep_arr = electr_ep.split(',');
     let electr_port = this.config.electrum_config.port
 
-    console.log(`electr host: ${electr_ep}`)
     if (electr_port) {
       if (Array.isArray(electr_port)) {
         if (electr_port.length !== electr_ep_arr.length) {
@@ -206,8 +205,7 @@ export class Wallet {
       state_entity_endpoint: this.config.state_entity_endpoint,
       electrum_endpoint: electr_ep,
     }
-    let tor_ep_set = this.http_client.post('tor_endpoints', endpoints_config);
-    console.log(`Set tor endpoints: ${tor_ep_set}}`);
+    this.http_client.post('tor_endpoints', endpoints_config);
   }
 
   // Generate wallet form mnemonic. Testing mode uses mock State Entity and Electrum Server.
@@ -663,7 +661,7 @@ export class Wallet {
     if (priv_key === undefined) throw Error("Backup receive address private key not found.");
 
     backup_tx_data.priv_key_hex = priv_key.toString("hex");
-    backup_tx_data.key_wif = bip32.toWIF();
+    backup_tx_data.key_wif = `p2wpkh:${bip32.toWIF()}`;
 
     if (statecoin.tx_cpfp !== null) {
       let fee_rate = (FEE + (backup_tx_data?.output_value ?? 0) - (statecoin.tx_cpfp?.outs[0]?.value ?? 0)) / 250;
@@ -724,9 +722,7 @@ export class Wallet {
         }
         // in mempool - check if confirmed
         if (this.statecoins.coins[i].backup_status === BACKUP_STATUS.IN_MEMPOOL) {
-          console.log(`in mempool.`)
           let txid = this!.statecoins!.coins[i]!.tx_backup!.getId();
-          console.log(`txid: ${txid}`)
           if (txid != null) {
             this.electrum_client.getTransaction(txid).then((tx_data: any) => {
               if (tx_data.confirmations !== undefined && tx_data.confirmations > 2) {
@@ -791,7 +787,14 @@ export class Wallet {
 
     let backup_tx_data = this.getCoinBackupTxData(cpfp_data.selected_coin);
 
-    var ec_pair = bitcoin.ECPair.fromWIF(backup_tx_data.key_wif, this.config.network);
+    let i_prefix = backup_tx_data.key_wif.search(/:/)
+    let wif_prefix = backup_tx_data.key_wif.slice(0, i_prefix);
+    if (wif_prefix !== 'p2wpkh') {
+      throw Error(`WIF prefix - expected p2wpkh, got ${wif_prefix}`);
+    }
+    let wif_key = backup_tx_data.key_wif.slice(i_prefix+1);
+    
+    var ec_pair = bitcoin.ECPair.fromWIF(wif_key, this.config.network);
     var p2wpkh = bitcoin.payments.p2wpkh({ pubkey: ec_pair.publicKey, network: this.config.network })
 
     // Construct CPFP tx
@@ -1011,7 +1014,7 @@ export class Wallet {
         return true
       }
     } catch (err: any) {
-      console.log(err);
+      log.error(err);
     }
     return false
   }
@@ -1282,7 +1285,9 @@ export class Wallet {
       try {
         await this.deRegisterSwapCoin(statecoin)
       } catch (e) {
-        log.info(e)
+        if (!e.message.includes("Coin is not in a swap pool")) {
+          throw e
+        }
       }
       statecoin.swap_auto = false;
     }
@@ -1301,7 +1306,7 @@ export class Wallet {
               if (statecoin && statecoin?.swap_status !== SWAP_STATUS.Phase4) {
                 statecoin.setSwapDataToNull();
               } else {
-                console.log(`resuming swap for statechain id: ${statecoin.statechain_id}`)
+                log.info(`resuming swap for statechain id: ${statecoin.statechain_id}`)
                 this.resume_swap(statecoin)
               }
             }


### PR DESCRIPTION
New feature: option to hide balance - issue #912:
- A check box is placed at the top of the main page which toggles the 'hide balance' setting.
- When 'hide balance' is set to true, the total balance is hidden and the coin balances are hidden in the coins list.
Fix: build up of wallet warnings - issue #1292:
- The number of log outputs is reduced.