### PR TITLE
Disable hardware acceleration

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -12,6 +12,8 @@ const fork = require('child_process').fork;
 const exec = require('child_process').exec;
 require('@electron/remote/main').initialize()
 
+app.disableHardwareAcceleration()
+
 function getPlatform() {
   switch (process.platform) {
     case 'aix':

--- a/src/electron-starter.js
+++ b/src/electron-starter.js
@@ -16,6 +16,8 @@ const execFile = require('child_process').execFile;
 if (!require("./settings.json").testing_mode) {
   require('@electron/remote/main').initialize()
 }
+
+app.disableHardwareAcceleration()
   
 const getPlatform = () => {
   switch (process.platform) {


### PR DESCRIPTION
This removes the following warning when starting the linux .AppImage:

mesa: for the --simplifycfg-sink-common option: may only occur zero or one times!
mesa: for the --global-isel-abort option: may only occur zero or one times!
mesa: for the --amdgpu-atomic-optimizations option: may only occur zero or one times!
