### PR TITLE
HOTFIX: Issue #1633 - Err in Wallet Load

### DIFF
--- a/src/containers/Send/Send.js
+++ b/src/containers/Send/Send.js
@@ -257,7 +257,7 @@ const SendStatecoinPage = () => {
               <button type="action-btn-normal" 
                 className = { `btn send-action-button ${loading} 
                 ${ (selectedCoins.length > 1 && !(inputAddr.substring(0,4) === 'xpub' || inputAddr.substring(0,4) === 'tpub'))?("privacy"): (null)  }
-                ${inputAddr && inputAddr.substring(0,4) === 'xpub' || inputAddr.substring(0,4) === 'tpub' ? (`xpub-key ${selectedCoins.length}`) : null }`} >
+                ${typeof(inputAddr) == "string" && (inputAddr.substring(0,4) === 'xpub' || inputAddr.substring(0,4) === 'tpub') ? (`xpub-key ${selectedCoins.length}`) : null }`} >
                 {loading ? (<Loading />) : "SEND STATECOIN"}
               </button>
             </ConfirmPopup >

--- a/src/store.ts
+++ b/src/store.ts
@@ -284,9 +284,11 @@ export class Storage {
   getSwappedCoinsByOutPoint(wallet_name: string, depth: number, outpoint: OutPoint) {
     let swapped_ids = this.getSwappedIds(wallet_name, outpoint);
 
-    swapped_ids = swapped_ids.slice(-depth);
+    if(swapped_ids){
+      swapped_ids = swapped_ids.slice(-depth);
+      
+    }
     let result = [];
-
     for (let i in swapped_ids) {
       const swappedCoin = this.getSwappedCoin(wallet_name, swapped_ids[i]);
       result.push(swappedCoin);

--- a/src/wallet/test/wallet.test.js
+++ b/src/wallet/test/wallet.test.js
@@ -1779,7 +1779,7 @@ describe('Storage 4', () => {
       outPoint)
     expect(shared_key_ids).toEqual(["89ee7160-0c27-4d0a-b10c-c7c3d7637d15"])
     //Check that swapped statecoins can be retrieved from outpoints
-    let swapped_coins_by_output = loaded_wallet.getSwappedStatecoinsByFundingOutPoint(outPoint)
+    let swapped_coins_by_output = loaded_wallet.getSwappedStatecoinsByFundingOutPoint(outPoint,1)
     expect(swapped_coins_by_output).toEqual([swapped_coins[0]])
     
     //Check that trying to retrieve a non existent coin throws an error
@@ -1791,6 +1791,15 @@ describe('Storage 4', () => {
     await loaded_wallet.removeStatecoin(s1[0].shared_key_id)
     loaded_wallet = await Wallet.load(WALLET_NAME_6_BACKUP, WALLET_PASSWORD_6, true)
     expect(loaded_wallet.statecoins.coins.length).toBe(s1.length - 1)
+
+    const outPoint2 = { txid: "NON-EXISTENT-UTXO", vout: "8" }
+    // OutPoint of coin that has not been swapped before
+
+    let swapHistory = loaded_wallet.getSwappedStatecoinsByFundingOutPoint(outPoint2,1);
+
+    expect(swapHistory).toStrictEqual([])
+
+    
 
   })
 })
@@ -1957,6 +1966,15 @@ describe('Storage 5', () => {
       loaded_wallet = await Wallet.load(WALLET_NAME_7_BACKUP, WALLET_PASSWORD_7, true);
       // Expect zero -length arrays for statecoin data
       expect(loaded_wallet.statecoins.coins.length).toEqual(0);
+
+
+      const outPoint2 = { txid: "NON-EXISTENT-UTXO".funding_txid, vout: "8" }
+      // OutPoint of coin that has not been swapped before
+  
+      let swapHistory = loaded_wallet.getSwappedStatecoinsByFundingOutPoint(outPoint2,1);
+  
+      expect(swapHistory).toStrictEqual([])
+
     })
   })  
 
@@ -1993,5 +2011,12 @@ describe('Storage 5', () => {
 
     test('loaded wallet with no statecoins has statecoins.coins array with length 0', async () => {
       expect(loaded_wallet.statecoins.coins.length).toEqual(0)
+
+      const outPoint = { txid: "NON-EXISTENT-UTXO", vout: "0" }
+      // OutPoint of coin that has not been swapped before
+  
+      let swapHistory = loaded_wallet.getSwappedStatecoinsByFundingOutPoint(outPoint,1);
+  
+      expect(swapHistory).toStrictEqual([])
     })
   })


### PR DESCRIPTION
Issue #1633

• Old wallet files don't have "swapped_ids" properties in store
    - Loading this property returns undefined
    - undefined values have no property .slice