### PR TITLE
Remove block height call on init

### DIFF
--- a/src/features/WalletDataSlice.js
+++ b/src/features/WalletDataSlice.js
@@ -336,8 +336,6 @@ export async function walletFromMnemonic(
   await mutex.runExclusive(async () => {
     await wallet.setHttpClient(networkType);
     await wallet.setElectrsClient(networkType);
-    //init Block height
-    await wallet.electrum_client.getLatestBlock(setBlockHeightCallBack, wallet.electrum_client.endpoint)
     wallet.initElectrumClient(setBlockHeightCallBack);
     if (try_restore) {
       let recoveryComplete = false;


### PR DESCRIPTION
There is no need for this before the wallet is created - it is set as soon as the wallet connects. 